### PR TITLE
Changes base box for VM from Ubuntu Trusty -> Debian Jessie

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "debian/contrib-jessie64"
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.define "securethenews" do |securethenews|
     securethenews.vm.hostname = "securethenews"


### PR DESCRIPTION
Debian Jessie ships a more recent version of python, specifically 2.7.9
rather than Trusty's 2.7.6. That makes sound support of SNI problematic
under Trusty, and SecureTheNews must have strong SNI support to work
correctly.

Using the `debian/contrib-jessie64` box rather than the more standard
`debian/jessie64` box to support automatic mounting of the `/vagrant`
guest directory from the host's git repo, so developers can continue to
make live changes to the config.
