### PR TITLE
Use polling with watchify to reliably autoreload JS

### DIFF
--- a/securethenews/gulpfile.js
+++ b/securethenews/gulpfile.js
@@ -16,7 +16,8 @@ var jadeify = require('jadeify');
 function compile(watch) {
   var bundler = watchify(browserify('./client/src/javascript/index.js', { debug: true })
     .transform(jadeify)
-    .transform(babel));
+    .transform(babel),
+    { poll: true });
 
   function rebundle() {
     bundler.bundle()


### PR DESCRIPTION
Resolves #21.
