### PR TITLE
Auto-configure tmux on login for dev productivity

### DIFF
--- a/ansible/roles/securethenews-deploy/defaults/main.yml
+++ b/ansible/roles/securethenews-deploy/defaults/main.yml
@@ -2,10 +2,12 @@
 apt_packages:
     - aptitude # needed by Ansible for apt upgrade
     - git
+    - ipython3
     - libjpeg-dev # Wagtail -> Pillow dependency
     - python-dev
     - python-pip
     - python3-pip
+    - ruby # for teamocil
     - tmux
     - vim
     - zlib1g-dev # Wagtail -> Pillow dependency

--- a/ansible/roles/securethenews-deploy/files/teamocil/dev.yml
+++ b/ansible/roles/securethenews-deploy/files/teamocil/dev.yml
@@ -1,0 +1,10 @@
+windows:
+  - name: dev
+    root: /vagrant/securethenews
+    layout: main-vertical
+    panes:
+      - commands:
+          - git status -sb
+        focus: true
+      - python3 manage.py runserver 0.0.0.0:8000
+      - gulp

--- a/ansible/roles/securethenews-deploy/tasks/main.yml
+++ b/ansible/roles/securethenews-deploy/tasks/main.yml
@@ -33,7 +33,42 @@
     global: yes
     name: gulp
 
+  # http://stackoverflow.com/questions/27341064/how-do-i-fix-importerror-cannot-import-name-incompleteread
+- name: Upgrade pip for Python 2 to avoid ImportError
+  become: yes
+  easy_install:
+    name: pip
+    state: latest
+
 - name: Install pshtt
   become: yes
   pip:
     name: pshtt
+
+- name: Install teamocil
+  become: yes
+  gem:
+    name: teamocil
+    user_install: no
+
+- name: Ensures teamocil layout directory exists
+  file:
+    path: ~/.teamocil
+    state: directory
+
+- name: Copy teamocil layout for Secure The News development
+  copy:
+    src: teamocil/dev.yml
+    dest: ~/.teamocil/dev.yml
+
+- name: Configure .bashrc to jump into dev environment on login
+  blockinfile:
+    dest: ~/.bashrc
+    insertafter: EOF
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    block: |
+      # Auto-start tmux and teamocil environment
+      if which tmux >/dev/null 2>&1; then
+          # if not inside a tmux session, and if no session is started, start a new session
+          test -z "$TMUX" && (tmux attach || tmux new-session -d "teamocil dev" \; attach)
+      fi


### PR DESCRIPTION
Uses teamocil to create a tmux layout for Secure The News development with 3 panes: a shell, `manage.py runserver`, and gulp.

Auto-starts tmux and teamocil with the dev layout on login.

Includes `ipython3` (which `manage.py shell` will use automatically if it's available) so the Django shell is more useful/productive.

Upgrades `pip` to avoid an issue with a version mismatch between the pip version included with Debian's `python-pip` package and the requests library. Solution derived from [Stack Overflow](http://stackoverflow.com/questions/27341064/how-do-i-fix-importerror-cannot-import-name-incompleteread).
