### PR TITLE
Logo animation easter egg

### DIFF
--- a/securethenews/client/src/styles/_header.scss
+++ b/securethenews/client/src/styles/_header.scss
@@ -54,4 +54,10 @@
   vertical-align: middle;
   width: 48px;
   height: 48px;
+
+  transition: 0.5s ease-in-out;
+
+  &:hover {
+    transform: rotate(-45deg);
+  }
 }


### PR DESCRIPTION
Just for fun! When you mouse onto or away from the logo, it rotates as if you had inserted a key and were turning it to unlock. Reinforces the "pen nib is keyhole" visual metaphor.