### PR TITLE
Custom branding for the Wagtail admin

### DIFF
--- a/securethenews/home/templates/wagtailadmin/admin_base.html
+++ b/securethenews/home/templates/wagtailadmin/admin_base.html
@@ -1,0 +1,6 @@
+{% extends "wagtailadmin/admin_base.html" %}
+{% load static %}
+
+{% block branding_favicon %}
+    <link rel="shortcut icon" href="{% static 'images/favicon.ico' %}" />
+{% endblock %}

--- a/securethenews/home/templates/wagtailadmin/base.html
+++ b/securethenews/home/templates/wagtailadmin/base.html
@@ -1,0 +1,6 @@
+{% extends "wagtailadmin/base.html" %}
+{% load static %}
+
+{% block branding_logo %}
+    <img src="{% static 'images/logo.svg' %}" alt="Secure the News" width="80" />
+{% endblock %}

--- a/securethenews/home/templates/wagtailadmin/home.html
+++ b/securethenews/home/templates/wagtailadmin/home.html
@@ -1,0 +1,3 @@
+{% extends "wagtailadmin/home.html" %}
+
+{% block branding_welcome %}Welcome to Secure the News{% endblock %}

--- a/securethenews/home/templates/wagtailadmin/login.html
+++ b/securethenews/home/templates/wagtailadmin/login.html
@@ -1,0 +1,3 @@
+{% extends "wagtailadmin/login.html" %}
+
+{% block branding_login %}Sign in to Secure the News{% endblock %}


### PR DESCRIPTION
http://docs.wagtail.io/en/v1.7/advanced_topics/customisation/branding.html

Customizes the Wagtail Admin to use the Secure the News logo and favicon. Also customizes the admin login welcome text and the welcome text on the main admin page.

<img width="919" alt="screen shot 2016-11-12 at 5 37 33 pm" src="https://cloud.githubusercontent.com/assets/407302/20243135/e34f1d0c-a8fe-11e6-8ecf-4412a5d928e8.png">
