### PR TITLE
Includes ALLOWED_HOSTS config in settings/production.py

### DIFF
--- a/securethenews/securethenews/settings/production.py
+++ b/securethenews/securethenews/settings/production.py
@@ -3,8 +3,15 @@ from __future__ import absolute_import, unicode_literals
 from .base import *
 import os
 
+
 DEBUG = False
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
+ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS').split(' ')
+
+try:
+    CSRF_TRUSTED_ORIGINS = os.environ['DJANGO_CSRF_TRUSTED_ORIGINS'].split(' ')
+except KeyError:
+    pass
 
 try:
     from .local import *


### PR DESCRIPTION
For production deployments, Django validates the Host header in requests and checks it against a list of permitted hosts, e.g. FQDNs. Let's read those in from an environment variable. Declaration of the environment
variable is required, otherwise the split() call will fail. This is intentional.

Also adding optional support for CSRF_TRUSTED_ORIGINS, again only in prod settings.

Closes #38.