### PR TITLE
Use absolute URLs for Sites in frontend JS

### DIFF
--- a/securethenews/client/src/javascript/leaderboardtemplate.jade
+++ b/securethenews/client/src/javascript/leaderboardtemplate.jade
@@ -31,7 +31,7 @@ mixin check(condition)
         for item in items
           tr.leaderboard-row
             td
-              a(href=item.slug)= item.name
+              a(href=item.absolute_url)= item.name
               if item.pledge
                 a(href=item.pledge.url)
                   i.pledged.fa.fa-handshake-o(title="#{ item.name } have pledged to secure their site.")

--- a/securethenews/client/src/javascript/teasertemplate.jade
+++ b/securethenews/client/src/javascript/teasertemplate.jade
@@ -1,8 +1,5 @@
 .teaser
   for site in sites
-    //- TODO We should pass through the absolute URL from the model instead of
-    //- constructing it ourselves because the current approach is prone to
-    //- breakage if we ever change the URLconf.
-    a(href='/sites/#{site.slug}')
+    a(href=site.absolute_url)
       span(class='graded-news-org')= site.name
         span(class='grade #{site.grade.class_name}')= site.grade.grade

--- a/securethenews/sites/models.py
+++ b/securethenews/sites/models.py
@@ -42,8 +42,8 @@ class Site(models.Model):
         # TODO optimize this (denormalize latest scan into Site?)
         return dict(
             name=self.name,
-            slug=self.slug,
             domain=self.domain,
+            absolute_url=self.get_absolute_url(),
             pledge=self.pledge.to_dict() if self.pledge else None,
             **self.scans.latest().to_dict()
         )


### PR DESCRIPTION
Tradeoff: this wastes some space in the sites_json, since it repeats the
URL prefix for each site. However, this should compress well so I don't
think it will have a significant impact on network transfer performance.

Benefit: We can change sites.urls without breaking the frontend code.

Also fixes an issue where the leaderboard on the homepage had incorrect
links to the site score pages because the leaderboard view was using
relative links.