### PR TITLE
Unicode slugs

### DIFF
--- a/securethenews/sites/models.py
+++ b/securethenews/sites/models.py
@@ -25,7 +25,7 @@ class Site(models.Model):
         return self.name
 
     def clean(self):
-        self.slug = slugify(self.name)
+        self.slug = slugify(self.name, allow_unicode=True)
         if len(self.slug) == 0:
             raise ValidationError('Slug must not be an empty string')
 


### PR DESCRIPTION
Fixes an issue that we encountered with `tass.ru,ТАСС` from `news_sites.csv`. Since ТАСС is all non-ASCII characters, Django's built-in `slugify` generated an empty slug for it. This issue came to light due to #47, manifesting as a 500 error, because `Site.get_absolute_url` for ТАСС tried to call `reverse` with an empty slug, which obviously doesn't work.

This PR:

1. Uses Mozilla's [unicode-slugify](https://github.com/mozilla/unicode-slugify) to generate Unicode-aware slugs.
2. Validates that `slug != ''` before saving Sites to prevent this bug from popping up again in the future.

## What do the Unicode URLs look like?

At the moment, the slugs will contain Unicode characters. Note that URLs are restricted to ASCII characters according to the spec; however, it is common practice to percent-encode Unicode characters for use in URLs, and all modern browsers handle this correctly. Here's what it looks like:

<img width="847" alt="screen shot 2016-11-18 at 1 47 45 pm" src="https://cloud.githubusercontent.com/assets/407302/20447807/b2a06db4-ad95-11e6-9297-9491acf5eec3.png">

If you copy-paste the URL, you will see it is actually percent-encoded "behind the scenes": `http://localhost:8000/sites/%D1%82%D0%B0%D1%81%D1%81`.

## Potential alternative

The other alternative is to **transliterate** non-ASCII characters to ASCII in the manner of [unidecode](https://pypi.python.org/pypi/Unidecode). This can be easily achieved with `django-unicode` by passing `only_ascii=True` to `slugify`.

I am not sure which solution is best, but I do think we should make a final decision about this before the site is launched - changing this after launch will cause URLs to break, and I'd prefer to avoid dealing with setting up redirects for these pages if I can.