### PR TITLE
STN-64 Configures MEDIA_ROOT production settings via env var

### DIFF
--- a/securethenews/securethenews/settings/production.py
+++ b/securethenews/securethenews/settings/production.py
@@ -30,6 +30,7 @@ DATABASES = {
 }
 
 STATIC_ROOT = os.environ['DJANGO_STATIC_ROOT']
+MEDIA_ROOT = os.environ['DJANGO_MEDIA_ROOT']
 
 try:
     es_host = os.environ.get('DJANGO_ES_HOST', 'disable')


### PR DESCRIPTION
Site-specific configs should be able to override and determine
media/static roots at deploy time, without updating the app code repo.
This approach was already in place for the STATIC_ROOT directive, but
not for MEDIA_ROOT; MEDIA_ROOT is now configurable via env var.