### PR TITLE
STN-68 Redirect URLs without trailing slashes

### DIFF
--- a/securethenews/securethenews/settings/base.py
+++ b/securethenews/securethenews/settings/base.py
@@ -151,5 +151,3 @@ WAGTAIL_SITE_NAME = "securethenews"
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 BASE_URL = 'http://example.com'
-
-WAGTAIL_APPEND_SLASH = False


### PR DESCRIPTION
This restores the default behavior of Django/Wagtail.

I originally set `WAGTAIL_APPEND_SLASH = False` because I thought the trailing slashes looked ugly in conjunction with the header permalinks added in 88d6e41. e.g.

* `https://securethe.news/why/#higher-search-rankings`
  * ugly (IMHO)
  * inconsistent with inspiration (ReadTheDocs)
* `https://securethe.news/why#higher-search-rankings`
  * not ugly
  * consistent with inspiration

However, I think this is a relatively minor aesthetic issue, and I think it is more important that URLs behave according to the "principle of least astonishment". This PR reverts to the less-astonishing default behavior, wherein _every_ Django/Wagtail page canonically has a trailing slash, and Django/Wagtail automatically redirects URLs without a trailing slash.