### PR TITLE
Enabled optional json logging in prod settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ env/
 
 # Development database backups
 db_backups/
+
+# Log files
+logs/

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -1,4 +1,5 @@
 Django>=1.10,<1.11
+django-logging-json==1.5.3
 gunicorn==19.6.0
 Pillow==3.4.2
 psycopg2==2.6.2

--- a/securethenews/securethenews/settings/production.py
+++ b/securethenews/securethenews/settings/production.py
@@ -51,3 +51,14 @@ try:
         WAGTAILSEARCH_BACKENDS['default']['use_ssl'] = True
 except KeyError:
     pass
+
+# Django json logging
+#
+if os.environ.get('DJANGO_LOG', 'no').lower() in ['true', 'yes']:
+    INSTALLED_APPS.append('django_logging')
+    MIDDLEWARE_CLASSES.append('django_logging.middleware.DjangoLoggingMiddleware')
+    DJANGO_LOGGING = {
+        "CONSOLE_LOG": False,
+        "SQL_LOG": False,
+        "LOG_LEVEL": os.environ.get('DJANGO_LOG_LEVEL', 'info')
+    }


### PR DESCRIPTION
Requires the environment variable `DJANGO_LOG` be set to 'true' or 'yes'.
Will dump log files into ${root_directory_django_codebase} + `/logs`.