### PR TITLE
Supports targeting a single site for scanning

### DIFF
--- a/securethenews/sites/management/commands/scan.py
+++ b/securethenews/sites/management/commands/scan.py
@@ -53,7 +53,9 @@ class Command(BaseCommand):
 
 
     def add_arguments(self, parser):
-        parser.add_argument('sites', nargs='*', type=str, default='')
+        parser.add_argument('sites', nargs='*', type=str, default='',
+            help=("Specify one or more domain names of sites to scan. "
+                  "If unspecified, scan all sites."))
 
 
     def handle(self, *args, **options):


### PR DESCRIPTION
**DO NOT MERGE—contains breaking changes.**

Running the `manage.py scan` command previously updated site scan
results for all sites known. This update modifies the command to accept
(mandatory) positional arguments for site names, e.g.

  manage.py scan nytimes

update only those.

This is a partial implementation, because the change breaks the current
default behavior of `manage.py scan`, since it naively demands
positional arguments now.