### PR TITLE
Increase pshtt timeout to 5 seconds

### DIFF
--- a/securethenews/sites/management/commands/scan.py
+++ b/securethenews/sites/management/commands/scan.py
@@ -8,7 +8,7 @@ from sites.models import Site, Scan
 
 
 def pshtt(domain):
-    pshtt_cmd = ['pshtt', '--json', domain]
+    pshtt_cmd = ['pshtt', '--json', '--timeout', '5', domain]
 
     p = subprocess.Popen(
         pshtt_cmd,


### PR DESCRIPTION
Conor noticed that when he tried to scan securethe.news, it got an F. This was highly surprising because securethe.news has valid HTTPS, defaults to HTTPS, uses HSTS, and is preload-ready -- it should've gotten an A. We debugged the issue together and found that pshtt uses a default timeout of 1 second for its scanning requests. Combined with the poor performance on the unoptimized securethe.news homepage (it takes ~1.5 seconds to render on average), pshtt was timing out before the homepage finished loading, which caused the incorrect results that we observed.

This PR increases pshtt's timeout to 5 seconds, which makes the ultimate scan results more robust in the context of slow sites or transient network issues.

We re-scanned the current site list with the new settings and compared the scores to make sure none of the existing sites had been incorrectly assessed for the same reason, and determined that none had been.