### PR TITLE
Modify BASE_URL for notification emails

### DIFF
--- a/securethenews/securethenews/settings/base.py
+++ b/securethenews/securethenews/settings/base.py
@@ -152,4 +152,4 @@ WAGTAIL_SITE_NAME = "securethenews"
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-BASE_URL = 'http://example.com'
+BASE_URL = 'https://securethe.news'

--- a/securethenews/securethenews/settings/production.py
+++ b/securethenews/securethenews/settings/production.py
@@ -7,6 +7,7 @@ import os
 DEBUG = False
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS').split(' ')
+BASE_URL = os.environ.get('DJANGO_BASE_URL', 'https://securethe.news')
 
 try:
     CSRF_TRUSTED_ORIGINS = os.environ['DJANGO_CSRF_TRUSTED_ORIGINS'].split(' ')


### PR DESCRIPTION
Currently defaults to example.com which of course is confusing and looks silly.
Was really only affecting wagtail admin emails (password resets and post
moderation alerts).