### PR TITLE
Purge frontend cache when saving Scans

### DIFF
--- a/securethenews/sites/apps.py
+++ b/securethenews/sites/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class SitesConfig(AppConfig):
     name = 'sites'
+
+    def ready(self):
+        import sites.signals

--- a/securethenews/sites/signals.py
+++ b/securethenews/sites/signals.py
@@ -1,0 +1,19 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.urls import reverse
+
+from wagtail.contrib.wagtailfrontendcache.utils import purge_url_from_cache
+
+from sites.models import Scan
+
+
+@receiver(post_save, sender=Scan)
+def invalidate_frontend_cache_for_site(sender, instance, **kwargs):
+    # Purge site-specific score breakdown page
+    purge_url_from_cache(reverse(instance.site))
+
+    # Purge the leaderboard
+    purge_url_from_cache(reverse('sites:index'))
+
+    # Purge the home page because it displays a subset of the leaderboard, as well as some summary statistics.
+    purge_url_from_cache('/')


### PR DESCRIPTION
Whenever a Scan is saved, purges the corresponding site-specific page,
the leaderboard, and the homepage. This automatically keeps the scores
visible on the site up-to-date with the latest scan data.

Leverages Wagtail's frontend cache invalidator, and its
purge_url_from_cache utility function, to do frontend cache invalidation
for pages even though they are not Wagtail pages.

In the common "mass scan" use case (`python manage.py scan`, which is
run periodically by a cron job), this approach is slightly inefficient:
it sends O(n) cache invalidation requests for the leaderboard and
homepage, one for each site, in rapid succession. It would be nice to
handle the "mass scan" use case more efficiently, but since the number
of sites is relatively low (~100), I think the current approach is
sufficient for now.

Closes #67.