### PR TITLE
Support Docker provider for development environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,20 +2,31 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "debian/contrib-jessie64"
+
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "forwarded_port", guest: 35729, host: 35729 # livereload
+
   config.vm.define "securethenews" do |securethenews|
     securethenews.vm.hostname = "securethenews"
-    securethenews.vm.provision "ansible" do |ansible|
-      ansible.playbook = "ansible/playbook.yml"
+
+    securethenews.vm.provider "docker" do |d|
+      d.build_dir = 'docker'
+      d.has_ssh = true
     end
+
     securethenews.vm.provider "virtualbox" do |vb|
+      config.vm.box = "debian/contrib-jessie64"
       # Building nodejs packages triggers the OOM killer with 512MB of RAM.
       vb.memory = 1024
     end
+
     securethenews.vm.provider "libvirt" do |lv|
+      config.vm.box = "debian/contrib-jessie64"
       lv.memory = 1024
+    end
+
+    securethenews.vm.provision "ansible" do |ansible|
+      ansible.playbook = "ansible/playbook.yml"
     end
   end
 end

--- a/ansible/roles/securethenews-deploy/tasks/main.yml
+++ b/ansible/roles/securethenews-deploy/tasks/main.yml
@@ -16,6 +16,20 @@
     update_cache: yes
     cache_valid_time: 86400
 
+  # http://stackoverflow.com/questions/27341064/how-do-i-fix-importerror-cannot-import-name-incompleteread
+- name: Upgrade pip for Python 2 to avoid ImportError
+  become: yes
+  easy_install:
+    name: pip
+    state: latest
+
+- name: Upgrade pip for Python 3 to avoid ImportError
+  become: yes
+  easy_install:
+    executable: easy_install3
+    name: pip
+    state: latest
+
   # https://www.digitalocean.com/community/tutorials/how-to-install-the-django-web-framework-on-ubuntu-14-04
 - name: Install Django project requirements
   become: yes
@@ -32,13 +46,6 @@
   npm:
     global: yes
     name: gulp
-
-  # http://stackoverflow.com/questions/27341064/how-do-i-fix-importerror-cannot-import-name-incompleteread
-- name: Upgrade pip for Python 2 to avoid ImportError
-  become: yes
-  easy_install:
-    name: pip
-    state: latest
 
 - name: Install pshtt
   become: yes

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM jesselang/debian-vagrant:jessie
+
+# The containers needs to have Python 2.7 installed in order for the Ansible
+# provisioner to work. You might expect jesselang/debian-vagrant to include
+# Python by default, since it is based on the official Debian images, but these
+# official images use a "minbase" install which does not appear to include
+# Python.
+RUN apt-get install --no-install-recommends -y python


### PR DESCRIPTION
Provides a Qubes-compatible alternative for automatically provisioning a
development environment for Secure The News.

Moves `config.vm.box` definition inside the `virtualbox` and `vagrant`
provider-specific configuration blocks, since it is only relevant to them and
causes errors when used in conjunction with the Docker provider.