### PR TITLE
Fix bug in computing "Available over HTTPS"

### DIFF
--- a/securethenews/client/src/javascript/leaderboardtemplate.jade
+++ b/securethenews/client/src/javascript/leaderboardtemplate.jade
@@ -38,7 +38,7 @@ mixin check(condition)
             td.desktop-only
               +check(item.valid_https)
             td.desktop-only
-              +check(item.valid_https && !item.downgrades_https)
+              +check(item.valid_https && item.downgrades_https === false)
             td.desktop-only
               +check(item.defaults_to_https)
             td.desktop-only


### PR DESCRIPTION
Parker noticed that abcnews.go.com was listed as being "Available over HTTPS"
on Secure the News, but when accesssed in a web browser it appears to downgrade
HTTPS to HTTP. We checked the headers with `curl -I`, which shows that it is
not serving an HTTP redirect to the insecure origin; however, it may be using
another technique to redirect (e.g. `<meta redirect>` or Javascript).

Without thoroughly investigating exactly what abcnews.go.com is doing, it is
clear that is confusing pshtt, which returns `"Downgrades HTTPS": null` while
simultaneously returning `"Valid HTTPS": true`. This appears to be a bug in
pshtt. This issue is compounded by using the `!` negation operator in the
leaderboard template, because that will type coerce `null` to `false`, which
causes Secure the News to incorrectly display "Availble over HTTPS".

This commit fixes the mistaken results displayed on the leaderboard template,
and I will file a follow-up issue on pshtt to address the issue with the scan
results.