### PR TITLE
Remove default usage of a git deploy_key

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -9,10 +9,7 @@ Need the following local requirements:
 * `virtualbox`
 * `virtualenv`
 
-Hooray! Now perform the following:
-
-* Copy a github private deploy key to `devops/deploy_key`
-* From the `devops` directory run `make`
+Hooray! Now from the `devops` directory run `make`
 
 This should setup a vagrant box and run an ansible play against it.
 You will then be able to get to a local STN instance @ `https://localhost:4443` in

--- a/devops/playbook.yml
+++ b/devops/playbook.yml
@@ -87,11 +87,9 @@
         - ssl_certificate_key /etc/ssl/private/{{ansible_fqdn}}-key.pem
     nodejs_version: "4.x"
     nodejs_install_npm_user: "{{ django_stack_gcorn_user }}"
-    django_stack_git_deploy:
-      - key: "{{ lookup('file','deploy_key') }}"
+    django_stack_git_deploy: []
     django_stack_git_repo:
-      - url: git@github.com:freedomofpress/securethenews.git
-        key: "/home/gcorn/.ssh/github_deploy"
+      - url: https://github.com/freedomofpress/securethenews.git
     django_stack_manage_post:
       - loaddata fixtures/prod.json
     django_stack_shell_commands:


### PR DESCRIPTION
This is no longer needed when STN repo is public. Not sure this readme will
really affect many people since it relies on libvirt/kvm plus having the jessie64
 image locally.