### PR TITLE
Pin django-analytical to fix mixed content issue

### DIFF
--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -1,5 +1,5 @@
 Django>=1.10,<1.11
-django-analytical==2.2.1
+git+https://github.com/jcassee/django-analytical.git@e8e2d841588ad3d60ba602a79b8feca632ca99a3#egg=django-analytical
 django-logging-json==1.5.3
 django-mailgun==0.9.1
 gunicorn==19.6.0


### PR DESCRIPTION
django-analytical's Piwik integration introduced a mixed content issue on
Secure the News for users with Javascript disabled because it hard-coded an
http scheme for the fallback tracking pixel. I fixed the issue upstream in
https://github.com/jcassee/django-analytical/pull/101, but the maintainers
haven't cut a new release yet, so for now we will pin to the fixed commit on
the upstream master branch.