### PR TITLE
Fix Vagrant on Mac

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,26 +2,27 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-
-  config.vm.network "forwarded_port", guest: 8000, host: 8000
-  config.vm.network "forwarded_port", guest: 35729, host: 35729 # livereload
-
   config.vm.define "securethenews" do |securethenews|
+    securethenews.vm.box = "debian/contrib-jessie64"
     securethenews.vm.hostname = "securethenews"
 
-    securethenews.vm.provider "docker" do |d|
+    securethenews.vm.network "forwarded_port", guest: 8000, host: 8000
+    securethenews.vm.network "forwarded_port", guest: 35729, host: 35729 # livereload
+
+    securethenews.vm.provider "docker" do |d, override|
       d.build_dir = 'docker'
       d.has_ssh = true
+
+      # Avoid error caused by defining vm.box for the Docker provider
+      override.vm.box = nil
     end
 
     securethenews.vm.provider "virtualbox" do |vb|
-      config.vm.box = "debian/contrib-jessie64"
       # Building nodejs packages triggers the OOM killer with 512MB of RAM.
       vb.memory = 1024
     end
 
     securethenews.vm.provider "libvirt" do |lv|
-      config.vm.box = "debian/contrib-jessie64"
       lv.memory = 1024
     end
 


### PR DESCRIPTION
* Fix the Vagrant development environment on Mac. Tested and confirmed
to work. Make sure you're using Ansible >= 2.0 on your host and you're
using the most up-to-date version of the "debian/contrib-jessie64" box.

* Cleaner solution for avoiding a Vagrant error due to defining a box
when using the Docker provider.

Resolves #79.