### PR TITLE
Update main.yml

### DIFF
--- a/ansible/roles/securethenews-deploy/tasks/main.yml
+++ b/ansible/roles/securethenews-deploy/tasks/main.yml
@@ -51,6 +51,7 @@
   become: yes
   pip:
     name: git+git://github.com/dhs-ncats/pshtt@7362a8bdabe7190a933e4c5e18561ba9d07dc561#egg=pshtt
+    executable: pip2.7
 
 - name: Install teamocil
   become: yes


### PR DESCRIPTION
Fixes #96 looks like the base docker image uses python 3 as default.  This ensures we use python 2.7 for pshtt/nassl etc.