### PR TITLE
Infra 318 django bump

### DIFF
--- a/devops/Makefile
+++ b/devops/Makefile
@@ -2,16 +2,16 @@ all: molecule
 
 pip: venv
 	. ./venv/bin/activate; \
-	pip install -r django_stack/requirements.txt
+	pip install -r roles/freedomofpress.djang_stack/requirements.txt
 
-venv:
+venv: galaxy
 	virtualenv venv
 
-molecule: galaxy
+molecule: pip
 	. ./venv/bin/activate && molecule create; \
 	molecule converge
 
-galaxy: pip
+galaxy:
 	ansible-galaxy install -r requirements.yml
 
 syncdjango:
@@ -19,3 +19,6 @@ syncdjango:
 
 destroy:
 	. ./venv/bin/activate && molecule destroy
+
+login:
+	. ./venv/bin/activate && molecule login

--- a/devops/molecule.yml
+++ b/devops/molecule.yml
@@ -28,4 +28,4 @@ vagrant:
       raw_config_args:
         - "vm.network 'forwarded_port', guest: 443, host: 4443"
         - "vm.network 'forwarded_port', guest: 80, host: 8080"
-        - "vm.synced_folder './', '/vagrant', disabled: true"
+        - "vm.synced_folder '../', '/var/www/django'"

--- a/devops/playbook.yml
+++ b/devops/playbook.yml
@@ -62,8 +62,11 @@
     - role: geerlingguy.nodejs
       tags: ['node']
 
-    - role: django_stack
+    - role: freedomofpress.django_stack
       tags: ['django']
+  post_tasks:
+    - debug:
+        msg: "You can hit the www interface at https://{{ ansible_default_ipv4.address }} or https://localhost:4443"
   vars:
     django_stack_superuser_admin: admin
     django_stack_superuser_email: webmaster@freedom.press
@@ -88,8 +91,7 @@
     nodejs_version: "4.x"
     nodejs_install_npm_user: "{{ django_stack_gcorn_user }}"
     django_stack_git_deploy: []
-    django_stack_git_repo:
-      - url: https://github.com/freedomofpress/securethenews.git
+    django_stack_git_repo: []
     django_stack_manage_post:
       - loaddata fixtures/prod.json
     django_stack_shell_commands:
@@ -117,3 +119,7 @@
       DJANGO_ALLOWED_HOSTS: "'*'"
       DJANGO_LOG: no
       DJANGO_LOG_LEVEL: debug
+    django_stack_gcorn_home: /home/vagrant
+    django_stack_gcorn_user: vagrant
+    django_stack_gcorn_group: vagrant
+    django_stack_force_refresh: true

--- a/devops/requirements.yml
+++ b/devops/requirements.yml
@@ -10,3 +10,6 @@
 
 - src: https://github.com/freedomofpress/ansible-elasticsearch
   name: elastic.elasticsearch
+
+- src: https://github.com/freedomofpress/django_stack.git
+  name: freedomofpress.django_stack

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.10,<1.11
+Django==1.10.7
 git+https://github.com/jcassee/django-analytical.git@e8e2d841588ad3d60ba602a79b8feca632ca99a3#egg=django-analytical
 django-logging-json==1.5.3
 django-mailgun==0.9.1


### PR DESCRIPTION
I saw some weird issues locally when trying to run from scratch that I wasnt able to reproduce in prod. In particular I needed to add in the following to my local roles copy:

```yaml
- name: Upgrade PIP
  pip:
    name: "{{ item }}"
    virtualenv_python: "{{ django_stack_venv_python }}"
    executable: "{{ django_stack_gcorn_home }}/{{ django_stack_app_name }}/bin/pip"
    virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
    extra_args: --upgrade
  with_items:
    - pip
    - setuptools
```

Should I add this upstream to `django_stack` ? im not really certain if theres any negative consequence to always updating pip + setuptools to the latest in prod, so I'm not sold on this without more testing. Id rather spend that testing time trying to implement pip deps into debian pkgs - but ill be willing to concede and add that in as a stop-gap now if someone can make a convincing argument. Run on sentences are ..... fun.