### PR TITLE
Add read-only REST API for site/scan data; enable CORS for GET/HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ for a given site (e.g., `/api/v1/sites` will return a directory, and
 and sort options are supported; click the "filters" dialog in the UI to explore
 them.
 
+To get all scans for a given site, you can use a path like
+`/api/v1/sites/bbc.co.uk/scans`. This URL can also be found in the all_scans
+field for a given site result.
+
 If you run a public site, note that read access to the API is available to any
 origin via CORS.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ Once you've installed the extension, simply load the development site in your
 browser (`localhost:8000`) and click the LiveReload extension icon to initiate
 live reloading.
 
+## API
+
+If everything is working correctly, you should be able to find an API endpoint
+at `localhost:8000/api` (it will redirect to the current API version).
+
+The API is read-only and can be used to obtain site metadata and the latest scan
+for a given site (e.g., `/api/v1/sites` will return a directory, and
+`/api/v1/sites/bbc.co.uk` will return details about the BBC). Various filters
+and sort options are supported; click the "filters" dialog in the UI to explore
+them.
+
+If you run a public site, note that read access to the API is available to any
+origin via CORS.
+
+The API is implemented using the Django REST framework; documentation for it can
+be found here:
+
+http://www.django-rest-framework.org/
+
 ## Notes
 
 * Port 8000 is forwarded from the guest to the host. By default, `runserver`

--- a/news_sites.csv
+++ b/news_sites.csv
@@ -104,12 +104,3 @@ msnbc.com,MSNBC
 cnet.com,CNET
 espn.com,ESPN
 gizmodo.com,Gizmodo Media
-climatecentral.org,Climate Central
-insideclimatenews.org,InsideClimate News
-thetrace.org,The Trace
-rewire.news,Rewire
-sciencenews.org,Science News
-theconversation.com,The Conversation
-motherjones.com,Mother Jones
-revealnews.org,Reveal
-democracynow.org,Democracy Now!

--- a/news_sites.csv
+++ b/news_sites.csv
@@ -104,3 +104,12 @@ msnbc.com,MSNBC
 cnet.com,CNET
 espn.com,ESPN
 gizmodo.com,Gizmodo Media
+climatecentral.org,Climate Central
+insideclimatenews.org,InsideClimate News
+thetrace.org,The Trace
+rewire.news,Rewire
+sciencenews.org,Science News
+theconversation.com,The Conversation
+motherjones.com,Mother Jones
+revealnews.org,Reveal
+democracynow.org,Democracy Now!

--- a/securethenews/api/apps.py
+++ b/securethenews/api/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class ApiConfig(AppConfig):
+    name = 'API'

--- a/securethenews/api/filters.py
+++ b/securethenews/api/filters.py
@@ -1,0 +1,13 @@
+import django_filters
+from sites.models import Site
+
+class SiteFilter(django_filters.rest_framework.FilterSet):
+    """
+    Defining a site filter lets the framework generate query URLs such as
+    ?domain=bbc.co.uk.
+    """
+    # This is nicer than the default, which only lets you input a specific date.
+    added_date = django_filters.DateTimeFromToRangeFilter(name='added')
+    class Meta:
+        model = Site
+        fields = ('name', 'domain', 'slug', 'added_date')

--- a/securethenews/api/filters.py
+++ b/securethenews/api/filters.py
@@ -3,17 +3,32 @@ Filters are used by the Django REST Framework to handle query URLs such as
 ?domain=bbc.co.uk.
 """
 import django_filters
-from sites.models import Site
+from sites.models import Site, Scan
 
 
 class SiteFilter(django_filters.rest_framework.FilterSet):
     """
-    Filter for selected fields and the date range in which a site was added
+    Filter for selected site fields and the date range in which a site was added
     """
     # This is nicer than the default, which only lets you input a specific
     # date.
-    added_date = django_filters.DateTimeFromToRangeFilter(name='added')
+    added_range = django_filters.DateTimeFromToRangeFilter(name='added')
 
     class Meta:
         model = Site
-        fields = ('name', 'domain', 'slug', 'added_date')
+        fields = ('name', 'domain', 'slug', 'added_range')
+
+
+class ScanFilter(django_filters.rest_framework.FilterSet):
+    """
+    Filter for selected scan fields and the date range in which a scan was
+    performed, as well as the score range among a list of scans
+    """
+    timestamp_range = django_filters.DateTimeFromToRangeFilter(
+        name='timestamp')
+    score_range = django_filters.RangeFilter(name='score')
+
+    class Meta:
+        model = Scan
+        fields = ('timestamp_range', 'live', 'valid_https',
+                  'defaults_to_https', 'score_range')

--- a/securethenews/api/filters.py
+++ b/securethenews/api/filters.py
@@ -1,13 +1,19 @@
+"""
+Filters are used by the Django REST Framework to handle query URLs such as
+?domain=bbc.co.uk.
+"""
 import django_filters
 from sites.models import Site
 
+
 class SiteFilter(django_filters.rest_framework.FilterSet):
     """
-    Defining a site filter lets the framework generate query URLs such as
-    ?domain=bbc.co.uk.
+    Filter for selected fields and the date range in which a site was added
     """
-    # This is nicer than the default, which only lets you input a specific date.
+    # This is nicer than the default, which only lets you input a specific
+    # date.
     added_date = django_filters.DateTimeFromToRangeFilter(name='added')
+
     class Meta:
         model = Site
         fields = ('name', 'domain', 'slug', 'added_date')

--- a/securethenews/api/serializers.py
+++ b/securethenews/api/serializers.py
@@ -1,12 +1,12 @@
-from django.core.exceptions import ObjectDoesNotExist
-from rest_framework import serializers
-from sites.models import Site, Scan
-
 """
 Serializers are used by the REST framework to generate the API output
 (and potentially to deserialize input, if we want to make the API writable
 in future).
 """
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import serializers
+from sites.models import Site, Scan
+
 
 class ScanSerializer(serializers.ModelSerializer):
     """
@@ -18,6 +18,7 @@ class ScanSerializer(serializers.ModelSerializer):
         # We don't need to expose the detailed program output, or the internal
         # IDs
         exclude = ('pshtt_stdout', 'pshtt_stderr', 'site', 'id')
+
 
 class SiteSerializer(serializers.ModelSerializer):
 

--- a/securethenews/api/serializers.py
+++ b/securethenews/api/serializers.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers
+from sites.models import Site, Scan
+
+"""
+Serializers are used by the REST framework to generate the API output
+(and potentially to deserialize input, if we want to make the API writable
+in future).
+"""
+
+class ScanSerializer(serializers.ModelSerializer):
+    """
+    We don't allow direct API access to scans; this serializer is only used
+    to generate the nested representation within a site object.
+    """
+    class Meta:
+        model = Scan
+        # We don't need to expose the detailed program output, or the internal
+        # IDs
+        exclude = ('pshtt_stdout', 'pshtt_stderr', 'site', 'id')
+
+class SiteSerializer(serializers.ModelSerializer):
+    scans = ScanSerializer(many=True)
+    class Meta:
+        model = Site
+        fields = ('name', 'slug', 'domain', 'added', 'scans')

--- a/securethenews/api/serializers.py
+++ b/securethenews/api/serializers.py
@@ -15,11 +15,16 @@ class ScanSerializer(serializers.ModelSerializer):
     Used for the latest_scan representation in a site view, as well as for
     the /sites/<domain>/scans list of all scans for a given domain.
     """
+    grade = serializers.SerializerMethodField()
+
     class Meta:
         model = Scan
         # We don't need to expose the detailed program output, or the internal
         # IDs
         exclude = ('pshtt_stdout', 'pshtt_stderr', 'site', 'id')
+
+    def get_grade(self, data):
+        return data.grade['grade']
 
 
 class SiteSerializer(serializers.ModelSerializer):

--- a/securethenews/api/tests.py
+++ b/securethenews/api/tests.py
@@ -1,4 +1,7 @@
-from rest_framework.test import  APITestCase
+"""
+Tests basic API operations against simple test data.
+"""
+from rest_framework.test import APITestCase
 from rest_framework import status
 from django.urls import reverse
 from sites.models import Site, Scan
@@ -6,9 +9,6 @@ from urllib.parse import urljoin
 
 urlroot = reverse('api-root')
 
-"""
-Tests basic API operations against simple test data.
-"""
 
 def create_site():
     """
@@ -76,7 +76,8 @@ class APIPermissionTests(APITestCase):
         <api root>/sites/ should not permit POST, PUT or DELETE operations
         """
         url = urljoin(urlroot, 'sites/securethe.news/')
-        response1 = self.client.post(url, json={'name': 'Insecure the News?', 'domain': 'insecurethe.news'})
+        response1 = self.client.post(
+            url, json={'name': 'Insecure the News?', 'domain': 'insecurethe.news'})
         self.assertEqual(response1.status_code,
                          status.HTTP_405_METHOD_NOT_ALLOWED)
 
@@ -85,6 +86,7 @@ class APIPermissionTests(APITestCase):
                          status.HTTP_405_METHOD_NOT_ALLOWED)
 
         url = urljoin(urlroot, 'sites/insecurethe.news/')
-        response3 = self.client.put(url, json={'name': 'Insecure the News?', 'domain': 'insecurethe.news'})
+        response3 = self.client.put(
+            url, json={'name': 'Insecure the News?', 'domain': 'insecurethe.news'})
         self.assertEqual(response3.status_code,
                          status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/securethenews/api/tests.py
+++ b/securethenews/api/tests.py
@@ -40,7 +40,7 @@ class APISiteTests(APITestCase):
 
     def test_get_sites(self):
         """
-        <api root>/sites should list sites/scans that have been created
+        <api root>/sites should list sites/scan that have been created
         """
         url = urljoin(urlroot, 'sites/')
         response = self.client.get(url, format='json')
@@ -49,8 +49,8 @@ class APISiteTests(APITestCase):
         self.assertEqual(len(response.data['results']), 1)
         sitedata = response.data['results'][0]
         self.assertEqual(sitedata['name'], 'Secure the News')
-        self.assertIn('scans', sitedata)
-        self.assertTrue(sitedata['scans'][0]['live'])
+        self.assertIn('latest_scan', sitedata)
+        self.assertTrue(sitedata['latest_scan']['live'])
 
 
 class APISiteDetailTests(APITestCase):
@@ -65,7 +65,6 @@ class APISiteDetailTests(APITestCase):
         url = urljoin(urlroot, 'sites/securethe.news/')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
 
 class APIPermissionTests(APITestCase):
     def setUp(self):

--- a/securethenews/api/urls.py
+++ b/securethenews/api/urls.py
@@ -1,0 +1,14 @@
+from . import views
+from django.conf.urls import url, include
+from django.views.generic import RedirectView
+
+urlpatterns = [
+    # We'll always redirect to the latest version; version should be an integer
+    # and changed only for breaking changes
+    url(r'^$', RedirectView.as_view(url='/api/v1')),
+    url(r'v1/$', views.api_root, name='api-root'),
+    url(r'v1/sites/$', views.SiteList.as_view(), name='site-list'),
+    # Standard lookup would be primary key, but we want lookup by domain
+    url(r'v1/sites/(?P<domain>.+)/$',
+        views.SiteDetail.as_view(), name='site-detail'),
+]

--- a/securethenews/api/urls.py
+++ b/securethenews/api/urls.py
@@ -9,9 +9,11 @@ urlpatterns = [
     # We'll always redirect to the latest version; version should be an integer
     # and changed only for breaking changes
     url(r'^$', RedirectView.as_view(url='/api/v1')),
-    url(r'v1/$', views.api_root, name='api-root'),
+    url(r'v1/$', views.api_root, name='api-root-v1'),
     url(r'v1/sites/$', views.SiteList.as_view(), name='site-list'),
     # Standard lookup would be primary key, but we want lookup by domain
+    url(r'v1/sites/(?P<domain>.+)/scans/$',
+        views.ScanList.as_view(), name='scan-list'),
     url(r'v1/sites/(?P<domain>.+)/$',
         views.SiteDetail.as_view(), name='site-detail'),
 ]

--- a/securethenews/api/urls.py
+++ b/securethenews/api/urls.py
@@ -1,3 +1,6 @@
+"""
+Registers API URLs
+"""
 from . import views
 from django.conf.urls import url, include
 from django.views.generic import RedirectView

--- a/securethenews/api/views.py
+++ b/securethenews/api/views.py
@@ -4,7 +4,7 @@ Django REST Framework views for the API
 from . import serializers, filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import routers, viewsets, generics, filters as rest_framework_filters
-from sites.models import Site
+from sites.models import Site, Scan
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -54,3 +54,20 @@ class SiteDetail(generics.RetrieveAPIView):
         # Passed in via URL regexp in urls.py
         domain = self.kwargs['domain']
         return Site.objects.filter(domain=domain)
+
+
+class ScanList(generics.ListAPIView):
+    """
+    List of all scans associated with a domain
+    """
+    serializer_class = serializers.ScanSerializer
+    filter_class = filters.ScanFilter
+
+    filter_backends = (rest_framework_filters.OrderingFilter,
+                       DjangoFilterBackend,)
+    ordering_fields = ('timestamp',)
+
+    def get_queryset(self):
+        # Passed in via URL regexp in urls.py
+        domain = self.kwargs['domain']
+        return Scan.objects.filter(site__domain=domain).order_by('-timestamp')

--- a/securethenews/api/views.py
+++ b/securethenews/api/views.py
@@ -18,7 +18,6 @@ def api_root(request, format=None):
     """
     Index of available API calls
     """
-
     return Response({
         'sites': reverse('site-list', request=request, format=format),
     })

--- a/securethenews/api/views.py
+++ b/securethenews/api/views.py
@@ -1,0 +1,55 @@
+from . import serializers, filters
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import routers, viewsets, generics, filters as rest_framework_filters
+from sites.models import Site
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+
+"""
+NOTE: Method docstrings in this file are used by the framework to generate
+page subtitles
+"""
+
+
+@api_view(['GET'])
+def api_root(request, format=None):
+    """
+    Index of available API calls
+    """
+
+    return Response({
+        'sites': reverse('site-list', request=request, format=format),
+    })
+
+
+class SiteList(generics.ListAPIView):
+    """
+    List of all SecureTheNews sites and the scan results for them
+    """
+    queryset = Site.objects.all()
+    serializer_class = serializers.SiteSerializer
+    filter_class = filters.SiteFilter
+
+    # Declaring the ordering filter lets users define ascending/descending
+    # order on selected fields, using the ?ordering= parameter
+    # Note that the two filters reside in different modules.
+    filter_backends = (rest_framework_filters.OrderingFilter,
+                       DjangoFilterBackend,)
+    ordering_fields = ('added', 'name', 'domain')
+
+
+class SiteDetail(generics.RetrieveAPIView):
+    """
+    Individual SecureTheNews site and its scan results
+    """
+    serializer_class = serializers.SiteSerializer
+
+    # By default only /site/<primary key> would work, but we want domain names
+    # to be used instead.
+    lookup_field = 'domain'
+
+    def get_queryset(self):
+        # Passed in via URL regexp in urls.py
+        domain = self.kwargs['domain']
+        return Site.objects.filter(domain=domain)

--- a/securethenews/api/views.py
+++ b/securethenews/api/views.py
@@ -1,3 +1,6 @@
+"""
+Django REST Framework views for the API
+"""
 from . import serializers, filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import routers, viewsets, generics, filters as rest_framework_filters
@@ -6,10 +9,8 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-"""
-NOTE: Method docstrings in this file are used by the framework to generate
-page subtitles
-"""
+# NOTE: Method docstrings in this file are used by the framework to generate
+# page subtitles
 
 
 @api_view(['GET'])

--- a/securethenews/api/views.py
+++ b/securethenews/api/views.py
@@ -25,7 +25,7 @@ def api_root(request, format=None):
 
 class SiteList(generics.ListAPIView):
     """
-    List of all SecureTheNews sites and the scan results for them
+    List of all SecureTheNews sites and the latest scan results for them
     """
     queryset = Site.objects.all()
     serializer_class = serializers.SiteSerializer
@@ -41,7 +41,7 @@ class SiteList(generics.ListAPIView):
 
 class SiteDetail(generics.RetrieveAPIView):
     """
-    Individual SecureTheNews site and its scan results
+    Individual SecureTheNews site and its latest scan results
     """
     serializer_class = serializers.SiteSerializer
 

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -1,7 +1,10 @@
 Django==1.10.7
 git+https://github.com/jcassee/django-analytical.git@e8e2d841588ad3d60ba602a79b8feca632ca99a3#egg=django-analytical
+django-crispy-forms==1.6.1
 django-logging-json==1.5.3
 django-mailgun==0.9.1
+django-filter==1.0.2
+django-cors-headers==2.0.2
 gunicorn==19.6.0
 Pillow==3.4.2
 psycopg2==2.6.2

--- a/securethenews/securethenews/settings/base.py
+++ b/securethenews/securethenews/settings/base.py
@@ -61,9 +61,15 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'analytical',
+
+    'django_filters',
+    'crispy_forms',
+    'rest_framework',
+    'corsheaders'
 ]
 
 MIDDLEWARE_CLASSES = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -76,6 +82,11 @@ MIDDLEWARE_CLASSES = [
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
 ]
+
+# Anyone can use the API via CORS
+CORS_ORIGIN_ALLOW_ALL = True
+# API is read-only
+CORS_ALLOW_METHODS = ('GET','HEAD','OPTIONS',)
 
 ROOT_URLCONF = 'securethenews.urls'
 
@@ -153,3 +164,15 @@ WAGTAIL_SITE_NAME = "securethenews"
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 BASE_URL = 'https://securethe.news'
+
+
+# API framework settings, relevant only for /api
+REST_FRAMEWORK = {
+    # For any query, users can set both limit and offset.
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    # A page has 100 results by default, but there's no upper limit.
+    'PAGE_SIZE': 100,
+}
+
+# Shiny forms for the web view of the API
+CRISPY_TEMPLATE_PACK = 'bootstrap3'

--- a/securethenews/securethenews/templates/rest_framework/api.html
+++ b/securethenews/securethenews/templates/rest_framework/api.html
@@ -1,0 +1,4 @@
+{% extends "rest_framework/base.html" %}
+{% block branding %}
+<a class="navbar-brand" href="/api">Secure the News API</a>
+{% endblock %}

--- a/securethenews/securethenews/urls.py
+++ b/securethenews/securethenews/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     url(r'^sites/', include('sites.urls')),
     url(r'^pledge/', include('pledges.urls')),
     url(r'^news/', include('blog.urls')),
+    url(r'^api/', include('api.urls')),
 
     url(r'', include(wagtail_urls)),
 ]


### PR DESCRIPTION
This uses the Django REST framework, which adds a nice browsable API
as well.

API can be found at /api/v1, /api redirects to it.