### PR TITLE
Update setuptools before installing SSLyze to prevent an error

### DIFF
--- a/ansible/roles/securethenews-deploy/tasks/main.yml
+++ b/ansible/roles/securethenews-deploy/tasks/main.yml
@@ -47,6 +47,13 @@
     global: yes
     name: gulp
 
+- name: Upgrade setuptools to avoid error while installing SSLyze
+  become: yes
+  pip:
+    name: setuptools
+    state: latest
+    executable: pip2.7
+
 - name: Install pshtt
   become: yes
   pip:


### PR DESCRIPTION
Fixes #118, based on the recommendation from https://github.com/nabla-c0d3/sslyze/issues/209.

This PR currently only adds the fix to the Ansible playbook responsible for provisioning the development environment. @msheiny What needs to be done to achieve the same fix in the production environment?