### PR TITLE
Corrected the site domain for NPR.

### DIFF
--- a/news_sites.csv
+++ b/news_sites.csv
@@ -1,7 +1,7 @@
 Domain Name,Organization Name
 indianexpress.com,The Indian Express
 nypost.com,New York Post
-npr.com,NPR
+npr.org,NPR
 usatoday.com,USA Today
 hindustantimes.com,Hindustan Times
 nytimes.com,The New York Times


### PR DESCRIPTION
NPR.com is a redirect to NPR.org.