### PR TITLE
INFRA-529 Address broken virtualenv delivery logic

### DIFF
--- a/molecule/ci/playbook.yml
+++ b/molecule/ci/playbook.yml
@@ -38,6 +38,10 @@
     django_stack_es_host_url: disable
     django_stack_deploy_src: "{{ molecule_scenario_directory }}/../../"
     django_stack_npm_install_cmd: "npm install; gulp build:production"
+    django_stack_venv_docker_image: "quay.io/freedomofpress/debian-jessie-venv:latest"
+    django_stack_venv_docker_cmd: sleep infinity
+    django_stack_venv_cmds:
+      - "/sbin/paxctl -cm {{ django_stack_venv_dir }}/bin/python"
     django_stack_gunicorn_opt_envs:
       DJANGO_ALLOWED_HOSTS: "'*'"
       DJANGO_SETTINGS_MODULE: securethenews.settings.production

--- a/molecule/ci/requirements.yml
+++ b/molecule/ci/requirements.yml
@@ -1,4 +1,4 @@
 ---
 - src: https://github.com/freedomofpress/ansible-role-django.git
   name: freedomofpress.django
-  version: master
+  version: AllowVENVOverride

--- a/molecule/ci/requirements.yml
+++ b/molecule/ci/requirements.yml
@@ -1,4 +1,4 @@
 ---
 - src: https://github.com/freedomofpress/ansible-role-django.git
   name: freedomofpress.django
-  version: AllowVENVOverride
+  version: master

--- a/molecule/ci/tests/test_logging.py
+++ b/molecule/ci/tests/test_logging.py
@@ -24,8 +24,6 @@ def request_and_scrape(url, filter_key, host):
     return filtered_json
 
 
-# Django JSON logging integration needs work
-@pytest.mark.xfail
 def test_json_log_exception(host):
     """
     Ensure json logging is working for exception
@@ -58,7 +56,7 @@ def test_json_log_200(host):
     """
 
     should_return = {"request":
-                        {"data": {}, 
+                        {"data": {},
                              "meta": {"http_host": "localhost:8000",
                                       "http_user_agent": "testinfra",
                                       "path_info": "/",

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,3 +1,4 @@
+ansible<2.4
 molecule>=2
 pip-tools
 docker

--- a/molecule/shared_tests/test_pshtt.py
+++ b/molecule/shared_tests/test_pshtt.py
@@ -4,8 +4,7 @@ import os
 
 PSHTT_CLI_PATH = os.environ['pshtt_location']
 PSHTT_DOMAINS = [
-    'freedom.press',
-    'securedrop.org'
+    'freedom.press'
 ]
 
 


### PR DESCRIPTION
Everyone said, why the hell are you shipping around virtualenv's that doesnt sound like a great idea .... Hah. Yep - that was good advice :| Anywhoo. This PR applies a fix for that situation that addresses deployments to debian jessie. Thanks to the Power Of the Django Ansible Role :tm:, this logic is extensible and relevant fixes can be made for other environments.

TL;DR - When building a virtualenv for deloyment, the build environnment needs to match the target environment.