### PR TITLE
Fix bugs in Ansible playbook that caused `make dev-go` to fail

### DIFF
--- a/molecule/dev/playbook.yml
+++ b/molecule/dev/playbook.yml
@@ -76,7 +76,7 @@
 
     - name: Build node image with pax flags
       docker_image:
-        name: "node_grsec:{{ node_tag }}"
+        name: "{{ node_grsec_image|default('node') }}:{{ node_tag }}"
         # Reuse custom NodeJS Dockerfile from CI
         dockerfile: "{{ molecule_scenario_directory }}/../ci/NodeDockerfile-stn"
         path: ../../
@@ -115,7 +115,7 @@
     - name: Start Django server
       docker_container:
         name: stn_django
-        image: "stn_django"
+        image: "stn_django:{{ requirements_hash }}"
         volumes:
           - ../../:/var/www/django
         state: started


### PR DESCRIPTION
- When the grsec kernel is not present, the previous logic caused
  a default Node image (without the custom CI Dockerfile) to be
  used. As a result, `npm install` would fail (due to missing
  `python` and `g++` dependencies) and `make dev-go` would time
  out at this stage.

- The SHA-256 hash was not appended to the name of the Django
  image. Once the bug above was fixed, this caused Docker to
  look for an image called `stn_django:latest` (`latest` is the
  default tag). Since that image does not exist, it would fail
  at this stage.