### PR TITLE
Static analysis via bandit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,12 @@ jobs:
             make flake8
 
       - run:
+          name: Static code analysis for vulnerabilities
+          command: |
+            . ~/.venv/bin/activate
+            make bandit
+
+      - run:
           name: Ensure Django service stands up
           command: |
             . ~/.venv/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 clean: ## Removes temporary gitignored development artifacts
 	rm -rvf db.sqlite3 node_modules client/build static
 
+.PHONY: bandit
+bandit: ## Runs `bandit` static code analysis tool for security bugs
+	bandit --recursive . -lll --exclude molecule,node_modules,.venv
+
 # Explaination of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.
 # 2. Check for second field matching, skip otherwise.

--- a/molecule/requirements.in
+++ b/molecule/requirements.in
@@ -1,4 +1,5 @@
 ansible>=2.4.2
+bandit
 molecule>=2
 pip-tools
 # Bug with ansible and docker 3.0+

--- a/molecule/requirements.in
+++ b/molecule/requirements.in
@@ -1,5 +1,7 @@
 ansible>=2.4.2
 molecule>=2
 pip-tools
-docker
+# Bug with ansible and docker 3.0+
+# https://github.com/ansible/ansible/issues/35612
+docker<3.0
 safety

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -12,6 +12,7 @@ asn1crypto==0.23.0        # via cryptography
 attrs==17.3.0             # via pytest
 backports.functools-lru-cache==1.2.1  # via arrow
 backports.ssl-match-hostname==3.5.0.1  # via docker
+bandit==1.4.0
 bcrypt==3.1.4             # via paramiko
 binaryornot==0.4.4        # via cookiecutter
 certifi==2017.11.5        # via requests
@@ -33,6 +34,8 @@ flake8==3.3.0             # via molecule
 funcsigs==1.0.2           # via pytest
 future==0.16.0            # via cookiecutter
 git-url-parse==1.0.2      # via python-gilt
+gitdb2==2.0.3             # via gitpython
+gitpython==2.1.8          # via bandit
 idna==2.6                 # via cryptography, requests
 ipaddress==1.0.18         # via cryptography, docker
 jinja2-time==0.2.0        # via cookiecutter
@@ -45,7 +48,7 @@ monotonic==1.4            # via fasteners
 packaging==16.8           # via dparse, safety
 paramiko==2.4.0           # via ansible
 pathspec==0.5.5           # via yamllint
-pbr==3.0.1                # via git-url-parse, molecule, python-gilt
+pbr==3.0.1                # via git-url-parse, molecule, python-gilt, stevedore
 pexpect==4.2.1            # via molecule
 pip-tools==1.11.0
 pluggy==0.6.0             # via pytest
@@ -62,11 +65,13 @@ pyparsing==2.2.0          # via packaging
 pytest==3.3.1             # via testinfra
 python-dateutil==2.6.1    # via arrow
 python-gilt==1.1.0        # via molecule
-pyyaml==3.12              # via ansible, ansible-lint, dparse, molecule, python-gilt, yamllint
+pyyaml==3.12              # via ansible, ansible-lint, bandit, dparse, molecule, python-gilt, yamllint
 requests==2.18.4          # via docker, safety
 safety==1.6.1
 sh==1.12.14               # via molecule, python-gilt
-six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, dparse, fasteners, git-url-parse, packaging, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
+six==1.11.0               # via ansible-lint, bandit, bcrypt, click-completion, cryptography, docker, docker-pycreds, dparse, fasteners, git-url-parse, packaging, pip-tools, pynacl, pytest, python-dateutil, stevedore, testinfra, websocket-client
+smmap2==2.0.3             # via gitdb2
+stevedore==1.28.0         # via bandit
 tabulate==0.7.7           # via molecule
 testinfra==1.7.1          # via molecule
 tree-format==0.1.1        # via molecule

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ django-filter
 django-mailgun
 elasticsearch
 gunicorn
-markdown2>=2.3.5  # required by pytable, forcing newer version for patch
+markdown2>=2.3.5  # required by pshtt, forcing newer version for patch
 pshtt
 psycopg2
 wagtail


### PR DESCRIPTION
**Depends on #149, review and merge that first.**

Adds static analysis via [bandit](https://github.com/openstack/bandit), as suggested by @emkll. Already wired up CI.