### PR TITLE
Patches pip dependencies (Django, markdown2, Ansible)

### DIFF
--- a/molecule/requirements.in
+++ b/molecule/requirements.in
@@ -1,4 +1,4 @@
-ansible<2.4
+ansible>=2.4.2
 molecule>=2
 pip-tools
 docker

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -5,12 +5,12 @@
 #    pip-compile --output-file molecule/requirements.txt molecule/requirements.in
 #
 ansible-lint==3.4.17      # via molecule
-ansible==2.3.2.0
+ansible==2.4.3.0
 anyconfig==0.9.1          # via molecule
 arrow==0.12.0             # via jinja2-time
 asn1crypto==0.23.0        # via cryptography
 attrs==17.3.0             # via pytest
-backports.functools_lru_cache==1.2.1  # via arrow
+backports.functools-lru-cache==1.2.1  # via arrow
 backports.ssl-match-hostname==3.5.0.1  # via docker
 bcrypt==3.1.4             # via paramiko
 binaryornot==0.4.4        # via cookiecutter
@@ -22,7 +22,7 @@ click==6.7                # via click-completion, cookiecutter, git-url-parse, m
 colorama==0.3.7           # via molecule, python-gilt
 configparser==3.5.0       # via flake8
 cookiecutter==1.5.1       # via molecule
-cryptography==2.1.4       # via paramiko
+cryptography==2.1.4       # via ansible, paramiko
 docker-pycreds==0.2.1     # via docker
 docker==2.6.1
 dparse==0.2.1             # via safety
@@ -56,7 +56,6 @@ py==1.5.2                 # via pytest
 pyasn1==0.4.2             # via paramiko
 pycodestyle==2.3.1        # via flake8
 pycparser==2.18           # via cffi
-pycrypto==2.6.1           # via ansible
 pyflakes==1.5.0           # via flake8
 pynacl==1.2.1             # via paramiko
 pyparsing==2.2.0          # via packaging

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django
+Django>=1.11.11<2
 django-analytical
 django-cors-headers
 django-crispy-forms

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ django-filter
 django-mailgun
 elasticsearch
 gunicorn
+markdown2>=2.3.5  # required by pytable, forcing newer version for patch
 pshtt
 psycopg2
 wagtail

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ django-mailgun==0.9.1
 django-modelcluster==3.1  # via wagtail
 django-taggit==0.22.1     # via wagtail
 django-treebeard==4.1.2   # via wagtail
-django==1.11.5
+django==1.11.11
 djangorestframework==3.6.4  # via wagtail
 docopt==0.6.2             # via pshtt
 dominate==2.3.1           # via pytablewriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ html5lib==0.999999999     # via wagtail
 idna==2.6                 # via cryptography, requests
 jsonschema==2.6.0         # via pytablereader
 logbook==1.1.0            # via dataproperty, pytablereader, pytablewriter, simplesqlite
-markdown2==2.3.4          # via pytablereader
+markdown2==2.3.5
 mbstrdecoder==0.2.2       # via pytablereader, pytablewriter, simplesqlite, typepy
 nassl==0.17.0             # via sslyze
 olefile==0.44             # via pillow


### PR DESCRIPTION
Bumps the `markdown2` dependency to satisfy the `make safety` check, by upgrading to a patched version. Also upgraded Ansible for a similar reason (bad `pycrypto` dependency), and finally bumped Django to 1.11.11 for the latest security fixes listed in https://www.djangoproject.com/weblog/2018/mar/06/security-releases/

Closes #153. 