### PR TITLE
Add major Colorado newspapers

### DIFF
--- a/news_sites.csv
+++ b/news_sites.csv
@@ -109,3 +109,4 @@ axios.com,Axios
 denverpost.com,Denver Post
 gazette.com,Colorado Springs Gazette
 dailycamera.com,Boulder Daily Camera
+chieftain.com, Pueblo Chieftain

--- a/news_sites.csv
+++ b/news_sites.csv
@@ -106,3 +106,6 @@ espn.com,ESPN
 gizmodo.com,Gizmodo Media
 nzz.ch,Neue Zürcher Zeitung
 axios.com,Axios
+denverpost.com,Denver Post
+gazette.com,Colorado Springs Gazette
+dailycamera.com,Boulder Daily Camera


### PR DESCRIPTION
The Denver Post, Colorado Springs Gazette, Pueblo Chieftain, and Boulder Daily Camera are the three largest papers by circulation in the State of Colorado, USA.