### PR TITLE
Upgrade safety and bandit for each run and regular safety checks in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 version: 2
 jobs:
-  build:
+  safety_check:
     machine: true
     working_directory: ~/securethenews
     steps:
@@ -19,17 +19,34 @@ jobs:
       - run:
           name: Check Python dependencies for CVEs
           command: |
+            pipenv install --selective-upgrade safety
             pipenv run make safety
+
+      - run:
+          name: Static code analysis for vulnerabilities
+          command: |
+            pipenv install --selective-upgrade bandit
+            pipenv run make bandit
+
+  build:
+    machine: true
+    working_directory: ~/securethenews
+    steps:
+      - checkout
+
+      - run:
+          name: Install testing pre-reqs
+          command: |
+            # Set python to 3.5.2
+            pyenv global 3.5.2
+            pip install -U pip
+            pip install pipenv
+            pipenv install
 
       - run:
           name: linters on the source
           command: |
             pipenv run make lint
-
-      - run:
-          name: Static code analysis for vulnerabilities
-          command: |
-            pipenv run make bandit
 
       - run:
           name: Ensure we can build and run dev env
@@ -51,3 +68,20 @@ jobs:
 
       - store_test_results:
           path: ~/securethenews/test-results
+
+workflows:
+  version: 2
+  securethenews_ci:
+    jobs:
+      - safety_check
+      - build
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - safety_check

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -3,7 +3,7 @@ django-analytical
 django-cors-headers
 django-crispy-forms
 django-filter
--e git+https://github.com/freedomofpress/django-logging.git@Remove_Elastic#egg=django-logging-json
+-e git+https://github.com/freedomofpress/django-logging.git@51f4fd4b02fafc3d6d9cddb5658247497404df7e#egg=django-logging-json
 django-mailgun
 elasticsearch
 gunicorn

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file /code/requirements.txt /code/requirements.in
 #
--e git+https://github.com/freedomofpress/django-logging.git@Remove_Elastic#egg=django-logging-json
+-e git+https://github.com/freedomofpress/django-logging.git@51f4fd4b02fafc3d6d9cddb5658247497404df7e#egg=django-logging-json
 asn1crypto==0.22.0        # via cryptography
 beautifulsoup4==4.6.0     # via pytablereader, wagtail
 certifi==2017.7.27.1      # via requests


### PR DESCRIPTION
- Add CI workflow for securethenews
- Add safety_check job that is run nightly and for each CI run
- Update bandit and safety each time the makefile target is called