### PR TITLE
Update cryptography

### DIFF
--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -11,6 +11,7 @@ markdown2>=2.3.5  # required by pshtt, forcing newer version for patch
 pshtt
 psycopg2
 python-json-logger
+sslyze>=1.4.3 # for cryptography >2.2
 unittest-xml-reporting
 wagtail
 wagtailmenus

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -10,7 +10,7 @@ beautifulsoup4==4.6.0     # via pytablereader, wagtail
 certifi==2017.7.27.1      # via requests
 cffi==1.10.0              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==1.9         # via pyopenssl, sslyze
+cryptography==2.2.2       # via pyopenssl, sslyze
 dataproperty==0.25.6      # via pytablereader, pytablewriter, simplesqlite
 django-analytical==2.2.2
 django-cors-headers==2.1.0
@@ -32,7 +32,7 @@ jsonschema==2.6.0         # via pytablereader
 logbook==1.1.0            # via dataproperty, pytablereader, pytablewriter, simplesqlite
 markdown2==2.3.5
 mbstrdecoder==0.2.2       # via pytablereader, pytablewriter, simplesqlite, typepy
-nassl==0.17.0             # via sslyze
+nassl==1.1.3              # via sslyze
 olefile==0.44             # via pillow
 path.py==10.4             # via pytablereader
 pathvalidate==0.16.1      # via pytablereader, pytablewriter, simplesqlite
@@ -52,8 +52,8 @@ requests-cache==0.4.13    # via pshtt
 requests==2.18.4          # via django-mailgun, pshtt, pytablereader, requests-cache, wagtail
 simplesqlite==0.15.0      # via pytablewriter
 six==1.10.0               # via cryptography, django-mailgun, html5lib, mbstrdecoder, pyopenssl, pytablereader, pytablewriter, python-dateutil, simplesqlite, typepy, unittest-xml-reporting
-sslyze==1.1.4             # via pshtt
-tls-parser==1.1.0         # via sslyze
+sslyze==1.4.3
+tls-parser==1.2.1         # via sslyze
 toml==0.9.2               # via pytablewriter
 typepy==0.0.20            # via dataproperty, pytablereader, pytablewriter, simplesqlite
 typing==3.6.2             # via nassl, sslyze, tls-parser


### PR DESCRIPTION
Cryptography < 2.3 was marked as vulnerable and needs to be updated to pass CI. sslyze requires a specific version of the cryptography library, and as such we need to bump sslyze