### PR TITLE
Bind Docker ports to localhost only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ update-pip-dependencies: ## Uses pip-compile to update requirements.txt
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 	@for req_file in `find . -type f -name '*requirements.txt'`; do \
 		echo "Checking file $$req_file" \
-		&& safety check --full-report -r $$req_file \
+		&& safety check --ignore 36351 --full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \
 	done

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
   postgresql:
     image: postgres:9.3
     ports:
-      - "5432"
+      - "127.0.0.1::5432"
     volumes:
       - ./:/django
     environment:
@@ -57,7 +57,7 @@ services:
       - ./:/django
       - ./logs:/django-logs
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     networks:
       app:
         aliases:


### PR DESCRIPTION
This ensures that containers are not exposed or reachable to other hosts
on local networks or VPN.

How to test: 
* Ensure securethenews is not impacted by CVE-2018-10903
* CI should pass
* Checkout master
* make dev
* open browser to `<IP_OF_HOST>:8000`
* observe web page
* checkout this branch
* make dev
* open browser to `<IP_OF_HOST>:8000`
* do not observe web page
