### PR TITLE
Upgrade to Django 1.11.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 	@for req_file in `find . -type f -name '*requirements.txt'`; do \
 		echo "Checking file $$req_file" \
 		&& safety check --ignore 36351 --ignore 36546 --ignore 36533 --ignore 36534\
-		--full-report -r $$req_file \
+		--ignore 36541 --full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \
 	done

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -1,5 +1,5 @@
 boto3 # s3 storage
-Django>=1.11.15<2
+Django>=1.11.18<2
 django-analytical
 django-cors-headers
 django-crispy-forms

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -24,7 +24,7 @@ django-modelcluster==3.1  # via wagtail
 django-storages[boto3,google]==1.7.1
 django-taggit==0.22.1     # via wagtail
 django-treebeard==4.1.2   # via wagtail
-django==1.11.15
+django==1.11.18
 djangorestframework==3.6.4  # via wagtail
 docopt==0.6.2             # via pshtt
 docutils==0.14            # via botocore


### PR DESCRIPTION
Due to CVE-2019-3498 (see https://www.djangoproject.com/weblog/2019/jan/04/security-releases/)