### PR TITLE
Update Django to 1.11.20

### DIFF
--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -1,5 +1,5 @@
 boto3 # s3 storage
-Django>=1.11.18<2
+Django>=1.11.20<2
 django-analytical
 django-cors-headers
 django-crispy-forms

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -24,7 +24,7 @@ django-modelcluster==3.1  # via wagtail
 django-storages[boto3,google]==1.7.1
 django-taggit==0.22.1     # via wagtail
 django-treebeard==4.1.2   # via wagtail
-django==1.11.18
+django==1.11.20
 djangorestframework==3.6.4  # via wagtail
 docopt==0.6.2             # via pshtt
 docutils==0.14            # via botocore


### PR DESCRIPTION
Fixes CVE-2019-6975 and packaging error introduced in 1.1.19, see:
* https://docs.djangoproject.com/en/dev/releases/1.11.19/
* https://docs.djangoproject.com/en/dev/releases/1.11.20/