### PR TITLE
Upgrade to Django 2.0.x

### DIFF
--- a/pledges/views.py
+++ b/pledges/views.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.core.mail import mail_admins, send_mail
 from django.core.exceptions import SuspiciousOperation
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 from django.template.loader import render_to_string

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -1,8 +1,8 @@
 boto3 # s3 storage
-Django>=1.11.20<2
+Django>=2.0.13,<2.1
 django-analytical
 django-cors-headers
-django-crispy-forms
+django-crispy-forms>=1.7.2
 django-filter
 -e git+https://github.com/freedomofpress/django-logging.git@51f4fd4b02fafc3d6d9cddb5658247497404df7e#egg=django-logging-json
 django-mailgun

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -18,14 +18,14 @@ dataproperty==0.25.6      # via pytablereader, pytablewriter, simplesqlite
 django-analytical==2.2.2
 django-cogwheels==0.2     # via wagtailmenus
 django-cors-headers==2.1.0
-django-crispy-forms==1.6.1
+django-crispy-forms==1.7.2
 django-filter==1.0.4
 django-mailgun==0.9.1
 django-modelcluster==4.3  # via wagtail
 django-storages[boto3,google]==1.7.1
 django-taggit==0.23.0     # via wagtail
 django-treebeard==4.3     # via wagtail
-django==1.11.20
+django==2.0.13
 djangorestframework==3.9.1  # via wagtail
 docopt==0.6.2             # via pshtt
 docutils==0.14            # via botocore

--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -69,13 +69,12 @@ INSTALLED_APPS = [
     'django_logging'
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',

--- a/securethenews/urls.py
+++ b/securethenews/urls.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 from search import views as search_views
@@ -10,19 +10,19 @@ from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 urlpatterns = [
-    url(r'^django-admin/', include(admin.site.urls)),
+    path('django-admin/', admin.site.urls),
 
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
+    path('admin/', include(wagtailadmin_urls)),
+    path('documents/', include(wagtaildocs_urls)),
 
-    url(r'^search/$', search_views.search, name='search'),
+    path('search/', search_views.search, name='search'),
 
-    url(r'^sites/', include('sites.urls')),
-    url(r'^pledge/', include('pledges.urls')),
-    url(r'^news/', include('blog.urls')),
-    url(r'^api/', include('api.urls')),
+    path('sites/', include('sites.urls')),
+    path('pledge/', include('pledges.urls')),
+    path('news/', include('blog.urls')),
+    path('api/', include('api.urls')),
 
-    url(r'', include(wagtail_urls)),
+    path('', include(wagtail_urls)),
 ]
 
 


### PR DESCRIPTION
This pull request:

1. Changes our Django requirement from 1.1.x to 2.0.x

2. Updates url definitions to be compatible with Django 2.0

3. Updates our middleware to be compatible with Django 2.0

4. Updates `django-crispy-forms` to be compatible with Django 2.0

Refs freedomofpress/fpf-www-projects#21