### PR TITLE
Upgrade to Django 2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ update-pip-dependencies: ## Uses pip-compile to update requirements.txt
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run -v "$(DIR)/securethenews:/code" -it quay.io/freedomofpress/ci-python \
-		bash -c 'pip install pip-tools && pip-compile \
+	docker run -v "$(DIR)/securethenews:/code" -it python:3.6-slim \
+		bash -c 'pip install pip-tools && apt-get update && apt-get install git -y && pip-compile \
 		--output-file /code/requirements.txt /code/requirements.in'
 
 .PHONY: safety

--- a/api/filters.py
+++ b/api/filters.py
@@ -13,7 +13,7 @@ class SiteFilter(django_filters.rest_framework.FilterSet):
     """
     # This is nicer than the default, which only lets you input a specific
     # date.
-    added_range = django_filters.DateTimeFromToRangeFilter(name='added')
+    added_range = django_filters.DateTimeFromToRangeFilter(field_name='added')
 
     class Meta:
         model = Site
@@ -26,8 +26,8 @@ class ScanFilter(django_filters.rest_framework.FilterSet):
     performed, as well as the score range among a list of scans
     """
     timestamp_range = django_filters.DateTimeFromToRangeFilter(
-        name='timestamp')
-    score_range = django_filters.RangeFilter(name='score')
+        field_name='timestamp')
+    score_range = django_filters.RangeFilter(field_name='score')
 
     class Meta:
         model = Scan

--- a/ci-docker-compose.yaml
+++ b/ci-docker-compose.yaml
@@ -4,7 +4,7 @@ networks:
   app:
 services:
   postgresql:
-    image: postgres:9.3
+    image: postgres:9.5
     ports:
       - "5432"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ networks:
   app:
 services:
   postgresql:
-    image: postgres:9.3
+    image: postgres:9.5
     ports:
       - "127.0.0.1::5432"
     volumes:

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -1,9 +1,9 @@
 boto3 # s3 storage
-Django>=2.0.13,<2.1
+Django>=2.1,<2.2
 django-analytical
 django-cors-headers
 django-crispy-forms>=1.7.2
-django-filter
+django-filter>=2.1.0
 -e git+https://github.com/freedomofpress/django-logging.git@51f4fd4b02fafc3d6d9cddb5658247497404df7e#egg=django-logging-json
 django-mailgun
 django-storages[boto3, google]>=1.7 # aws s3, google storage asset management

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -19,13 +19,13 @@ django-analytical==2.2.2
 django-cogwheels==0.2     # via wagtailmenus
 django-cors-headers==2.1.0
 django-crispy-forms==1.7.2
-django-filter==1.0.4
+django-filter==2.1.0
 django-mailgun==0.9.1
 django-modelcluster==4.3  # via wagtail
 django-storages[boto3,google]==1.7.1
 django-taggit==0.23.0     # via wagtail
 django-treebeard==4.3     # via wagtail
-django==2.0.13
+django==2.1.7
 djangorestframework==3.9.1  # via wagtail
 docopt==0.6.2             # via pshtt
 docutils==0.14            # via botocore
@@ -75,7 +75,6 @@ sslyze==1.1.4             # via pshtt
 tls-parser==1.1.0         # via sslyze
 toml==0.9.2               # via pytablewriter
 typepy==0.0.20            # via dataproperty, pytablereader, pytablewriter, simplesqlite
-typing==3.6.2             # via nassl, sslyze, tls-parser
 unidecode==0.4.21         # via wagtail
 unittest-xml-reporting==2.1.1
 urllib3==1.22             # via elasticsearch, requests


### PR DESCRIPTION
This pull request:

1. Changes the makefile to ensure that the `update-pip-dependencies` command runs under python 3.6

2. Upgrades our database container to postgresql 9.5

3. Updates Django to version 2.1.7 (the latest version as of now), and updates `django-filter` to the latest version to maintain compatibility.

Refs freedomofpress/fpf-www-projects#21