### PR TITLE
Bumps django-analytical 2.2 -> 2.5

### DIFF
--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -1,6 +1,6 @@
 boto3 # s3 storage
 Django>=2.1,<2.2
-django-analytical
+django-analytical>=2.5,<2.6
 django-cors-headers
 django-crispy-forms>=1.7.2
 django-filter>=2.1.0

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -15,7 +15,7 @@ cffi==1.10.0              # via cryptography
 chardet==3.0.4            # via requests
 cryptography==1.9         # via pyopenssl, sslyze
 dataproperty==0.25.6      # via pytablereader, pytablewriter, simplesqlite
-django-analytical==2.2.2
+django-analytical==2.5.0
 django-cogwheels==0.2     # via wagtailmenus
 django-cors-headers==2.1.0
 django-crispy-forms==1.7.2


### PR DESCRIPTION
We were pinning 2.2 because that worked well enough under Django 1.x.
Under 2.1, however, the analytics integration throws an error on a bool
type conversion. We saw the same error with the Django upgrade on another
website, and updating analytical to 2.5 resolved it, so doing the same here.