### PR TITLE
Enable PDB and development requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ update-pip-dependencies: ## Uses pip-compile to update requirements.txt
 # be resolved differently.
 	docker run -v "$(DIR)/securethenews:/code" -it python:3.6-slim \
 		bash -c 'pip install pip-tools && apt-get update && apt-get install git -y && pip-compile \
-		--output-file /code/requirements.txt /code/requirements.in'
+		--output-file /code/requirements.txt /code/requirements.in && \
+        pip-compile -U --no-header --output-file /code/dev-requirements.txt /code/dev-requirements.in'
 
 .PHONY: safety
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities

--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ of course, you can obtain a shell directly into any of the containers using `doc
 $ docker-compose exec django ash
 ```
 
+### Debugging
+
+If you want to use the [PDB](https://docs.python.org/3/library/pdb.html) program for debugging, it is possible.  First, add this line to an area of the code you wish to debug:
+
+```
+import ipdb; ipdb.set_trace()
+```
+
+Second, attach to the running Django container.  This must be done in a shell, and it is within this attached shell that you will be able to interact with the debugger.  The command to attach is `docker attach <ID_OF_DJANGO_CONTAINER>`, and on UNIX-type systems, you can look up the ID and attach to the container with this single command:
+
+```
+docker attach $(docker ps -aqf "name=freedompress_django")
+```
+
+Once you have done this, you can load the page that will run the code with your `import ipdb` and the debugger will activate in the shell you attached.
+
 ## Getting Started with the Production Environment
 
 The environment is fairly similar to development with the exception that your code will not auto-reload and be reflected in the container. So this is not a great environment to development under but it reflects a production-like environment run under `gunicorn` and behind a reverse-proxy nginx server.

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ import ipdb; ipdb.set_trace()
 Second, attach to the running Django container.  This must be done in a shell, and it is within this attached shell that you will be able to interact with the debugger.  The command to attach is `docker attach <ID_OF_DJANGO_CONTAINER>`, and on UNIX-type systems, you can look up the ID and attach to the container with this single command:
 
 ```
-docker attach $(docker ps -aqf "name=freedompress_django")
+docker attach $(docker-compose ps -q django)
 ```
 
-Once you have done this, you can load the page that will run the code with your `import ipdb` and the debugger will activate in the shell you attached.
+Once you have done this, you can load the page that will run the code with your `import ipdb` and the debugger will activate in the shell you attached. To detach from the shell without stopping the container press `Control+P` followed by `Control+Q`.
 
 ## Getting Started with the Production Environment
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,8 @@ services:
       - app
 
   django:
+    stdin_open: true
+    tty: true
     build:
       context: .
       dockerfile: docker/DevDjangoDockerfile

--- a/docker/DevDjangoDockerfile
+++ b/docker/DevDjangoDockerfile
@@ -26,7 +26,7 @@ ARG USERID
 RUN adduser -D -g "" -u "${USERID}" gcorn
 
 RUN paxctl -cm /usr/local/bin/python
-COPY securethenews/requirements.txt /requirements.txt
+COPY securethenews/dev-requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 
 RUN  mkdir /django-logs && \

--- a/docker/dev-django
+++ b/docker/dev-django
@@ -5,7 +5,7 @@ ARG USERID
 RUN adduser -D -g "" -u "${USERID}" gcorn
 
 RUN paxctl -cm /usr/local/bin/python
-COPY securethenews/requirements.txt /requirements.txt
+COPY securethenews/dev-requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 
 RUN  mkdir /django-logs && \

--- a/securethenews/dev-requirements.in
+++ b/securethenews/dev-requirements.in
@@ -1,0 +1,2 @@
+-r requirements.txt
+ipdb

--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -1,0 +1,96 @@
+-e git+https://github.com/freedomofpress/django-logging.git@51f4fd4b02fafc3d6d9cddb5658247497404df7e#egg=django-logging-json
+asn1crypto==0.22.0
+backcall==0.1.0           # via ipython
+beautifulsoup4==4.6.0
+boto3==1.7.48
+botocore==1.10.48
+cachetools==2.1.0
+certifi==2017.7.27.1
+cffi==1.10.0
+chardet==3.0.4
+cryptography==1.9
+dataproperty==0.25.6
+decorator==4.4.0          # via ipython, traitlets
+django-analytical==2.5.0
+django-cogwheels==0.2
+django-cors-headers==2.1.0
+django-crispy-forms==1.7.2
+django-filter==2.1.0
+django-mailgun==0.9.1
+django-modelcluster==4.3
+django-storages[boto3,google]==1.7.1
+django-taggit==0.23.0
+django-treebeard==4.3
+django==2.1.7
+djangorestframework==3.9.1
+docopt==0.6.2
+docutils==0.14
+dominate==2.3.1
+draftjs-exporter==2.0.0
+elasticsearch==5.4.0
+google-api-core==1.2.1
+google-auth==1.5.0
+google-cloud-core==0.28.1
+google-cloud-storage==1.10.0
+google-resumable-media==0.3.1
+googleapis-common-protos==1.5.3
+gunicorn==19.7.1
+html5lib==0.999999999
+idna==2.6
+ipdb==0.12
+ipython-genutils==0.2.0   # via traitlets
+ipython==7.5.0            # via ipdb
+jedi==0.13.3              # via ipython
+jmespath==0.9.3
+jsonschema==2.6.0
+logbook==1.1.0
+markdown2==2.3.5
+mbstrdecoder==0.2.2
+nassl==0.17.0
+olefile==0.44
+parso==0.4.0              # via jedi
+path.py==10.4
+pathvalidate==0.16.1
+pexpect==4.7.0            # via ipython
+pickleshare==0.7.5        # via ipython
+pillow==4.2.1
+prompt-toolkit==2.0.9     # via ipython
+protobuf==3.6.0
+pshtt==0.2.3
+psycopg2==2.7.3.1
+ptyprocess==0.6.0         # via pexpect
+publicsuffix==1.1.0
+pyasn1-modules==0.2.2
+pyasn1==0.4.3
+pycparser==2.18
+pygments==2.3.1           # via ipython
+pyopenssl==17.2.0
+pyparsing==2.2.0
+pytablereader==0.13.3
+pytablewriter==0.24.0
+python-dateutil==2.6.1
+python-json-logger==0.1.8
+pytz==2017.2
+requests-cache==0.4.13
+requests==2.18.4
+rsa==3.4.2
+s3transfer==0.1.13
+simplesqlite==0.15.0
+six==1.12.0
+sslyze==1.1.4
+tls-parser==1.1.0
+toml==0.9.2
+traitlets==4.3.2          # via ipython
+typepy==0.0.20
+unidecode==0.4.21
+unittest-xml-reporting==2.1.1
+urllib3==1.22
+wagtail==2.3
+wagtailmenus==2.12
+wcwidth==0.1.7            # via prompt-toolkit
+webencodings==0.5.1
+wget==3.2
+willow==1.1
+xlrd==1.1.0
+xlsxwriter==0.9.9
+xlwt==1.3.0


### PR DESCRIPTION
This pull request 

1. Adds the idea of development dependencies to this project, mostly copying how we do it elsewhere in our web sphere (e.g. see [Press Freedom Tracker](https://github.com/freedomofpress/tracker)).
2. Updates the docker compose settings to permit attaching such that you can interactively run the python debugger on our Django containers. I've also added some documentation for how to do this.

Refs freedomofpress/fpf-www-projects#39