### PR TITLE
Add make command to check for ungenerated migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
             echo "Wait for environemnt to come up completely"
             while ! curl --output /dev/null --silent --head --fail http://localhost:8000; do sleep 1 && echo -n .; done;
             pipenv run make app-tests-dev
+            pipenv run make check-migrations
             pipenv run docker-compose down
 
       - run:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ ci-go: ## Provisions and tests a prod-like setup.
 lint: ## Runs linters
 	flake8
 
+.PHONY: check-migrations
+check-migrations: ## Check for ungenerated migrations
+	docker-compose exec -T django bash -c "./manage.py makemigrations --dry-run --check"
+
 .PHONY: dev-createdevdata
 dev-createdevdata: ## Imports site data in dev environment.
 	docker-compose exec django bash -c "./manage.py migrate"


### PR DESCRIPTION
This pull request adds a make command to check for ungenerated migrations. I've also put the command into the CI config so it's run when building the site, so that we don't inadvertently merge any PRs without having included all necessary migrations.