### PR TITLE
Add "gitinfo" view

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,5 @@ node_modules
 client/build/
 media/
 molecule
-.git
 **/*.pyc
+.versioninfo

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ coverage.xml
 
 #visual studio code
 .vscode
+
+# Ignore files created to communicate system deployment info
+.versioninfo

--- a/docker/DevDjangoDockerfile
+++ b/docker/DevDjangoDockerfile
@@ -29,8 +29,8 @@ RUN paxctl -cm /usr/local/bin/python
 COPY securethenews/dev-requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 
-RUN  mkdir /django-logs && \
-     chown -R gcorn: /django-logs
+RUN  mkdir /django-logs /deploy && \
+     chown -R gcorn: /django-logs /deploy
 
 EXPOSE 8000
 USER gcorn

--- a/docker/ProdDjangoDockerfile
+++ b/docker/ProdDjangoDockerfile
@@ -62,6 +62,10 @@ RUN  mkdir /django-media /django-static /django-logs && \
 RUN mkdir -p /etc/gunicorn && chown -R gcorn: /etc/gunicorn
 COPY docker/gunicorn/gunicorn.py /etc/gunicorn/gunicorn.py
 
+RUN mkdir /deploy && \
+    chown -R gcorn: /deploy && \
+    /django/devops/scripts/version-file.sh
+
 EXPOSE 8000
 USER gcorn
 CMD django-start.sh

--- a/docker/ProdDjangoDockerfile
+++ b/docker/ProdDjangoDockerfile
@@ -64,7 +64,7 @@ COPY docker/gunicorn/gunicorn.py /etc/gunicorn/gunicorn.py
 
 RUN mkdir /deploy && \
     chown -R gcorn: /deploy && \
-    /django/devops/scripts/version-file.sh
+    /django/scripts/version-file.sh
 
 EXPOSE 8000
 USER gcorn

--- a/docker/django-start.sh
+++ b/docker/django-start.sh
@@ -28,6 +28,7 @@ django_start() {
         ./manage.py collectstatic -c --noinput
     fi
     if [ "${DEPLOY_ENV}" == "dev" ]; then
+        ./scripts/version-file.sh
         ./manage.py runserver 0.0.0.0:8000
     else
         gunicorn -c /etc/gunicorn/gunicorn.py securethenews.wsgi

--- a/home/views.py
+++ b/home/views.py
@@ -3,15 +3,13 @@ import os
 from django.http import HttpResponse
 
 
-GITINFO_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)),
-    'gitinfo')
+DEPLOYINFO_PATH = os.environ.get('DJANGO_VERSION_FILE', '/deploy/version')
 
 
-def gitinfo_view(request):
+def deploy_info_view(request):
     try:
-        with open(GITINFO_PATH, 'r') as f:
+        with open(DEPLOYINFO_PATH, 'r') as f:
             contents = f.read()
     except FileNotFoundError:
-        contents = "<file not found at {}>".format(GITINFO_PATH)
+        contents = "<file not found at {}>".format(DEPLOYINFO_PATH)
     return HttpResponse(contents, content_type='text/plain')

--- a/home/views.py
+++ b/home/views.py
@@ -1,0 +1,17 @@
+import os
+
+from django.http import HttpResponse
+
+
+GITINFO_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    'gitinfo')
+
+
+def gitinfo_view(request):
+    try:
+        with open(GITINFO_PATH, 'r') as f:
+            contents = f.read()
+    except FileNotFoundError:
+        contents = "<file not found at {}>".format(GITINFO_PATH)
+    return HttpResponse(contents, content_type='text/plain')

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -7,5 +7,5 @@ from .views import deploy_info_view
 @hooks.register('register_admin_urls')
 def urlconf_time():
     return [
-        url(r'^version/$', deploy_info_view, name='deployinfo'),
+        url(r'^version/?$', deploy_info_view, name='deployinfo'),
     ]

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -1,0 +1,11 @@
+from wagtail.core import hooks
+from django.conf.urls import url
+
+from .views import gitinfo_view
+
+
+@hooks.register('register_admin_urls')
+def urlconf_time():
+    return [
+        url(r'^gitinfo/$', gitinfo_view, name='gitinfo'),
+    ]

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -1,11 +1,11 @@
 from wagtail.core import hooks
 from django.conf.urls import url
 
-from .views import gitinfo_view
+from .views import deploy_info_view
 
 
 @hooks.register('register_admin_urls')
 def urlconf_time():
     return [
-        url(r'^gitinfo/$', gitinfo_view, name='gitinfo'),
+        url(r'^version/$', deploy_info_view, name='deployinfo'),
     ]

--- a/scripts/version-file.sh
+++ b/scripts/version-file.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+#
+#
+# Write deployment version information to a file on disk
+
+set -e
+
+DEPLOY_FILE="${DJANGO_VERSION_FILE:-/deploy/version}"
+
+cat /dev/null > "${DEPLOY_FILE}"
+
+echo -e "## GIT INFO #####\n" >> "${DEPLOY_FILE}"
+git log -5 --oneline >> "${DEPLOY_FILE}"
+
+echo -e "\n## PYTHON INFO #####" >> "${DEPLOY_FILE}"
+python --version >> "${DEPLOY_FILE}"
+
+echo -e "\n## PYTHON DEPS #####" >> "${DEPLOY_FILE}"
+pip freeze >> "${DEPLOY_FILE}"
+
+echo -e "\n## SYS INFO #####" >> "${DEPLOY_FILE}"
+cat /etc/*-release >> "${DEPLOY_FILE}"

--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -8,7 +8,7 @@ cachetools==2.1.0
 certifi==2017.7.27.1
 cffi==1.10.0
 chardet==3.0.4
-cryptography==2.3
+cryptography==2.2.2
 dataproperty==0.25.6
 decorator==4.4.0          # via ipython, traitlets
 django-analytical==2.5.0
@@ -47,7 +47,7 @@ jsonschema==2.6.0
 logbook==1.1.0
 markdown2==2.3.5
 mbstrdecoder==0.2.2
-nassl==2.1.0
+nassl==1.1.3
 olefile==0.44
 parso==0.4.0              # via jedi
 path.py==10.4
@@ -78,7 +78,7 @@ rsa==3.4.2
 s3transfer==0.1.13
 simplesqlite==0.15.0
 six==1.12.0
-sslyze==2.0.0
+sslyze==1.4.3
 tls-parser==1.2.1
 toml==0.9.2
 traitlets==4.3.2          # via ipython

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -13,6 +13,7 @@ markdown2>=2.3.5  # required by pshtt, forcing newer version for patch
 pshtt
 psycopg2
 python-json-logger
+sslyze<2  # pinning older version for python3.5 compatibility
 unittest-xml-reporting
 wagtail>=2.3,<2.4
 wagtailmenus>=2.12

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -13,7 +13,7 @@ cachetools==2.1.0         # via google-auth
 certifi==2017.7.27.1      # via requests
 cffi==1.10.0              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.3         # via pyopenssl, sslyze
+cryptography==2.2.2       # via pyopenssl, sslyze
 dataproperty==0.25.6      # via pytablereader, pytablewriter, simplesqlite
 django-analytical==2.5.0
 django-cogwheels==0.2     # via wagtailmenus
@@ -47,7 +47,7 @@ jsonschema==2.6.0         # via pytablereader
 logbook==1.1.0            # via dataproperty, pytablereader, pytablewriter, simplesqlite
 markdown2==2.3.5
 mbstrdecoder==0.2.2       # via pytablereader, pytablewriter, simplesqlite, typepy
-nassl==2.1.0              # via sslyze
+nassl==1.1.3              # via sslyze
 olefile==0.44             # via pillow
 path.py==10.4             # via pytablereader
 pathvalidate==0.16.1      # via pytablereader, pytablewriter, simplesqlite
@@ -72,7 +72,7 @@ rsa==3.4.2                # via google-auth
 s3transfer==0.1.13        # via boto3
 simplesqlite==0.15.0      # via pytablewriter
 six==1.12.0               # via cryptography, django-mailgun, google-api-core, google-auth, google-resumable-media, html5lib, mbstrdecoder, protobuf, pyopenssl, pytablereader, pytablewriter, python-dateutil, simplesqlite, typepy, unittest-xml-reporting, wagtail
-sslyze==2.0.0             # via pshtt
+sslyze==1.4.3
 tls-parser==1.2.1         # via sslyze
 toml==0.9.2               # via pytablewriter
 typepy==0.0.20            # via dataproperty, pytablereader, pytablewriter, simplesqlite


### PR DESCRIPTION
This pull request adds a view to the admin area that, essentially, reads from a file and displays those file contents to the admin. In theory, this file is filled with information about the current git commit/branch that's deployed, something like

```
git log HEAD --oneline --no-walk
```