### PR TITLE
Upgrade django to 2.1.10

### DIFF
--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -22,7 +22,7 @@ django-storages[boto3,google]==1.7.1
 django-taggit==0.23.0
 django-treebeard==4.3
 django-webpack-loader==0.6.0
-django==2.1.7
+django==2.1.10
 djangorestframework==3.9.1
 docopt==0.6.2
 docutils==0.14

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -1,4 +1,4 @@
-Django>=2.1,<2.2
+Django>=2.1.10,<2.2
 django-analytical>=2.5,<2.6
 django-cors-headers
 django-crispy-forms>=1.7.2

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -26,7 +26,7 @@ django-storages[boto3,google]==1.7.1
 django-taggit==0.23.0     # via wagtail
 django-treebeard==4.3     # via wagtail
 django-webpack-loader==0.6.0
-django==2.1.7
+django==2.1.10
 djangorestframework==3.9.1  # via wagtail
 docopt==0.6.2             # via pshtt
 docutils==0.14            # via botocore


### PR DESCRIPTION
This upgrade fixes a few security vulnerabilities.  

This change was generated by modifying `requirements.in` to require the version we want to upgrade to and running `make update-pip-dependencies`.

Refs freedomofpress/fpf-www-projects#58