### PR TITLE
Forces JSON log format in prod settings

### DIFF
--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/freedomofpress/django-logging.git@806e4a8b1dfbdb57947d0e60453074942f25bbe4#egg=django-logging-json
+-e git+https://github.com/freedomofpress/django-logging.git@34fbeeea7a83bd54f8551bb50382a06b69814d4e#egg=django-logging-json
 asn1crypto==0.22.0
 backcall==0.1.0           # via ipython
 beautifulsoup4==4.6.0
@@ -38,9 +38,9 @@ googleapis-common-protos==1.5.3
 gunicorn==19.7.1
 html5lib==0.999999999
 idna==2.6
-ipdb==0.12
+ipdb==0.12.2
 ipython-genutils==0.2.0   # via traitlets
-ipython==7.6.1            # via ipdb
+ipython==7.7.0            # via ipdb
 jedi==0.14.1              # via ipython
 jmespath==0.9.3
 jsonschema==2.6.0

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -3,7 +3,7 @@ django-analytical>=2.5,<2.6
 django-cors-headers
 django-crispy-forms>=1.7.2
 django-filter>=2.1.0
--e git+https://github.com/freedomofpress/django-logging.git@806e4a8b1dfbdb57947d0e60453074942f25bbe4#egg=django-logging-json
+-e git+https://github.com/freedomofpress/django-logging.git@34fbeeea7a83bd54f8551bb50382a06b69814d4e#egg=django-logging-json
 django-mailgun
 django-storages[boto3, google]>=1.7 # aws s3, google storage asset management
 django-webpack-loader

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=/code/requirements.txt /code/requirements.in
 #
--e git+https://github.com/freedomofpress/django-logging.git@806e4a8b1dfbdb57947d0e60453074942f25bbe4#egg=django-logging-json
+-e git+https://github.com/freedomofpress/django-logging.git@34fbeeea7a83bd54f8551bb50382a06b69814d4e#egg=django-logging-json
 asn1crypto==0.22.0        # via cryptography
 beautifulsoup4==4.6.0     # via pytablereader, wagtail
 boto3==1.7.48             # via django-storages

--- a/securethenews/settings/production.py
+++ b/securethenews/settings/production.py
@@ -130,7 +130,7 @@ LOG_TO_CONSOLE = bool(os.environ.get('DJANGO_LOG_CONSOLE', False))
 DJANGO_LOGGING = {
     "CONSOLE_LOG": LOG_TO_CONSOLE,
     "SQL_LOG": False,
-    "DISABLE_EXISTING_LOGGERS": False,
+    "DISABLE_EXISTING_LOGGERS": True,
     "PROPOGATE": False,
     "LOG_LEVEL": os.environ.get('DJANGO_LOG_LEVEL', 'info'),
     "LOG_PATH": LOG_DIR,


### PR DESCRIPTION
Two changes here, both intended to standardize the production logging story:

* Bumps logging reqs to include changes from https://github.com/freedomofpress/django-logging/pull/5
* Forces JSON logging format by disabling "other" loggers (which may not be logging in JSON)

Upon merge, the new container will be pushed to the testing cluster, and we can evaluate the logging change there.

### Testing

Using the prod docker-compose environment, you can observe that on current master, each request generates at least two events, on JSON and one plaintext:

> django_1      | [2019-08-12 16:26:10 +0000] [21] [DEBUG] GET /sites/
django_1      | {"created": 1565627171, "levelname": "INFO", "request": {"data": {}, "meta": {"http_host": "localhost:8000", "http_user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0", "path_info": "/sites/", "remote_addr": "172.18.0.1"}, "method": "GET", "path": "/sites/", "scheme": "http", "user": "AnonymousUser"}, "response": {"charset": "utf-8", "headers": {"Content-Type": "text/html; charset=utf-8"}, "reason": "OK", "status": 200}}

Whereas on this branch, after running `docker-compose -f prod-docker-compose.yaml up --build`, you'll see only one log event per request:

> django_1      | {"created": 1565628214, "levelname": "INFO", "request": {"data": {}, "meta": {"http_host": "localhost:8000", "http_user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0", "path_info": "/sites/", "remote_addr": "172.18.0.1"}, "method": "GET", "path": "/sites/", "scheme": "http", "user": "AnonymousUser"}, "response": {"charset": "utf-8", "headers": {"Content-Type": "text/html; charset=utf-8"}, "reason": "OK", "status": 200}}
django_1      | {"created": 1565628218, "levelname": "INFO", "request": {"data": {}, "meta": {"http_host": "localhost:8000", "http_user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0", "path_info": "/sites/the-intercept", "remote_addr": "172.18.0.1"}, "method": "GET", "path": "/sites/the-intercept", "scheme": "http", "user": "AnonymousUser"}, "response": {"charset": "utf-8", "headers": {"Content-Type": "text/html; charset=utf-8"}, "reason": "OK", "status": 200}}
django_1      | {"created": 1565628224, "levelname": "INFO", "request": {"data": {}, "meta": {"http_host": "localhost:8000", "http_user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0", "path_info": "/sites/", "remote_addr": "172.18.0.1"}, "method": "GET", "path": "/sites/", "scheme": "http", "user": "AnonymousUser"}, "response": {"charset": "utf-8", "headers": {"Content-Type": "text/html; charset=utf-8"}, "reason": "OK", "status": 200}}
django_1      | {"created": 1565628243, "levelname": "INFO", "request": {"data": {}, "meta": {"http_host": "localhost:8000", "http_user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0", "path_info": "/sites/the-moscow-times", "remote_addr": "172.18.0.1"}, "method": "GET", "path": "/sites/the-moscow-times", "scheme": "http", "user": "AnonymousUser"}, "response": {"charset": "utf-8", "headers": {"Content-Type": "text/html; charset=utf-8"}, "reason": "OK", "status": 200}}
django_1      | {"created": 1565628250, "exception": {"message": "", "traceback": [{"file": "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", "line": 124, "method": "_get_response"}, {"file": "/usr/local/lib/python3.6/site-packages/wagtail/core/views.py", "line": 17, "method": "serve"}, {"file": "/usr/local/lib/python3.6/site-packages/wagtail/core/models.py", "line": 610, "method": "route"}], "type": "django.http.response.Http404"}, "levelname": "ERROR", "request": {"data": {}, "meta": {"http_host": "localhost:8000", "http_user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0", "path_info": "/sites/the-moscow-times/asdlkfjsadf/", "remote_addr": "172.18.0.1"}, "method": "GET", "path": "/sites/the-moscow-times/asdlkfjsadf/", "scheme": "http", "user": "AnonymousUser"}}
django_1      | {"created": 1565628251, "levelname": "WARNING", "request": {"data": {}, "meta": {"http_host": "localhost:8000", "http_user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0", "path_info": "/sites/the-moscow-times/asdlkfjsadf/", "remote_addr": "172.18.0.1"}, "method": "GET", "path": "/sites/the-moscow-times/asdlkfjsadf/", "scheme": "http", "user": "AnonymousUser"}, "response": {"charset": "utf-8", "headers": {"Content-Type": "text/html; charset=utf-8"}, "reason": "Not Found", "status": 404}}
