### PR TITLE
Make createdevdata UI consistent with other projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,6 @@ lint: ## Runs linters
 check-migrations: ## Check for ungenerated migrations
 	docker-compose exec -T django bash -c "./manage.py makemigrations --dry-run --check"
 
-.PHONY: dev-createdevdata
-dev-createdevdata: ## Imports site data in dev environment.
-	docker-compose exec django bash -c "./manage.py migrate"
-	docker-compose exec django bash -c "./manage.py createdevdata"
-
 .PHONY: dev-makemigrations
 dev-migrate: ## Generates new db migrations and applies them.
 	docker-compose exec django bash -c "./manage.py makemigrations"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ at: http://localhost:8000
 To import the example data, run:
 
 ```bash
-make dev-createdevdata
+docker-compose exec django ./manage.py createdevdata
 ```
 
 This will also create an admin user for the web interface at


### PR DESCRIPTION
This pull request changes removes the makefile-based interface to the `createdevdata` command and updates the readme to instruct developers to invoke the command with `docker-compose` directly. This change brings this project into line with our other websites.

Refs freedomofpress/fpf-www-projects#38