### PR TITLE
Add Cameron Higby as trusted codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# Harris is codeowner for all website changes
-*   @harrislapiroff
+# Harris and Cameron are codeowners for all website changes
+*   @harrislapiroff @chigby
 
 # Mike should review testing changes, with Conor as backup
 molecule/   @msheiny @conorsch


### PR DESCRIPTION
Per internal discussion, Cameron is a highly trusted contributor, and this will increase velocity and give us more consistent coverage for reviews.