### PR TITLE
Remove Google Plus, fix Twitter share links

### DIFF
--- a/client/src/styles/_social.scss
+++ b/client/src/styles/_social.scss
@@ -1,6 +1,5 @@
 $facebookBlue: #354ba1;
 $twitterBlue: #139ae9;
-$gplusRed: #d5392f;
 $socialIconBorderWidth: 2px;
 
 .social-container {
@@ -42,13 +41,4 @@ $socialIconBorderWidth: 2px;
     }
   }
 
-  &.gplus {
-    color: $gplusRed;
-    border-color: $gplusRed;
-
-    &:hover {
-      background-color: $gplusRed;
-      color: #fff;
-    }
-  }
 }

--- a/securethenews/templates/shared/social.html
+++ b/securethenews/templates/shared/social.html
@@ -1,17 +1,12 @@
 <div class="social-icons">
-  <a  class="social-icon facebook"
-    href="https://www.facebook.com/sharer/sharer.php?u={{ url }}"
-    target="_blank">
-    <i class="fa fa-facebook" title="Facebook"></i>
-  </a>
   <a class="social-icon twitter"
-    href="https://twitter.com/home?status={{ url }}"
+    href="https://twitter.com/intent/tweet?url={{ url | urlencode }}"
     target="_blank">
     <i class="fa fa-twitter" title="Twitter"></i>
   </a>
-  <a class="social-icon gplus"
-    href="https://plus.google.com/share?url={{ url }}"
+  <a  class="social-icon facebook"
+    href="https://www.facebook.com/sharer/sharer.php?u={{ url | urlencode }}"
     target="_blank">
-    <i class="fa fa-google-plus" title="Google Plus"></i>
+    <i class="fa fa-facebook" title="Facebook"></i>
   </a>
 </div>


### PR DESCRIPTION
Both Facebook and Twitter share endpoints expect that URLs are
URL-encoded; Facebook gracefully redirects, while Twitter ignores
URLs that are not URL-encoded.

Resolves #208