### PR TITLE
Upgrade to latest version of npm and supported version of node

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,8 @@ services:
       context: .
       dockerfile: docker/NodeDockerfile
       args:
-        NODE_VER: 10.15.1-alpine
+        NODE_VER: 10.17.0-alpine
+        NPM_VER: 6.13.4
         USERID: ${UID:?err}
     volumes:
       - ./:/django

--- a/docker/NodeDockerfile
+++ b/docker/NodeDockerfile
@@ -1,8 +1,12 @@
 ARG NODE_VER
+ARG NPM_VER
 FROM node:${NODE_VER}
 
 # Make npm output less verbose
 ENV NPM_CONFIG_LOGLEVEL warn
+
+# Upgrade npm to speicifed version
+RUN npm install npm@${NPM_VER} -g
 
 # Workaround to avoid webpack hanging, see:
 # https://github.com/webpack/webpack-dev-server/issues/128

--- a/docker/ProdDjangoDockerfile
+++ b/docker/ProdDjangoDockerfile
@@ -1,8 +1,12 @@
 ARG NODE_VER
+ARG NPM_VER
 FROM node:${NODE_VER} AS node-assets
 
 # Make npm output less verbose
 ENV NPM_CONFIG_LOGLEVEL warn
+
+# Upgrade npm to speicifed version
+RUN npm install npm@${NPM_VER} -g
 
 # Workaround to avoid webpack hanging, see:
 # https://github.com/webpack/webpack-dev-server/issues/128

--- a/package-lock.json
+++ b/package-lock.json
@@ -3495,7 +3495,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3516,12 +3517,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3536,17 +3539,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3663,7 +3669,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3675,6 +3682,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3689,6 +3697,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3696,12 +3705,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3720,6 +3731,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3800,7 +3812,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3812,6 +3825,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3897,7 +3911,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3933,6 +3948,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3952,6 +3968,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3995,12 +4012,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/prod-docker-compose.yaml
+++ b/prod-docker-compose.yaml
@@ -23,7 +23,8 @@ services:
       context: .
       dockerfile: docker/ProdDjangoDockerfile
       args:
-        NODE_VER: 10.15.1-alpine
+        NODE_VER: 10.17.0-alpine
+        NPM_VER: 6.13.4
     image: quay.io/freedomofpress/securethenews
     read_only: true
     environment:


### PR DESCRIPTION
* In the process I've also extended our NodeDockerfile to allow
  us to easily specify an NPM version as part of the
  docker-compose file
* Since we are still on a supported LTS track with Node 10.x, I
  decided to conservatively upgrade to the latest version of Node
  10.x rather than upgrade to the absolutely latest Node (or even
  the latest LTS track, which is node 12.x)
* I also updated our NodeDockerfile to use CMD rather than
  ENTRYPOINT to run webpack. This is more consistent with how
  those declarations are intended:
  - Typically entrypoints accept a command and run some
    environment logic before passing the command along
  - This allows the command to be overridden by e.g. `docker run <cmd>`
* Among other things, this patches this vulnerability in npm
  https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli

Testing Instructions
--------------------

* Force a rebuild of the node container with
  ```bash
  docker-compose up --build --force-recreate --no-start node
  ```

* Confirm that
  ```bash
   docker-compose run node node --version
   ```
  yields `v10.17.0`

* Confirm that
  ```bash
   docker-compose run node node --version
   ```
  yields `6.13.4`

After Merge
------------

Every developer will need to force a rebuild of the node container for updates to be reflected in their dev environment:

  ```bash
  docker-compose up --build --force-recreate --no-start node
  ```