### PR TITLE
Expands git info on version endpoint

### DIFF
--- a/scripts/version-file.sh
+++ b/scripts/version-file.sh
@@ -11,6 +11,10 @@ DEPLOY_FILE="${DJANGO_VERSION_FILE:-/deploy/version}"
 cat /dev/null > "${DEPLOY_FILE}"
 
 echo -e "## GIT INFO #####\n" >> "${DEPLOY_FILE}"
+git_tag_info="$(git describe --exact-match || echo "N/A")"
+echo -e "git tag: ${git_tag_info}\n" >> "${DEPLOY_FILE}"
+git_branch_info="$(git rev-parse --abbrev-ref HEAD || echo "N/A")"
+echo -e "git branch: ${git_branch_info}\n" >> "${DEPLOY_FILE}"
 git log -5 --oneline >> "${DEPLOY_FILE}"
 
 echo -e "\n## PYTHON INFO #####" >> "${DEPLOY_FILE}"


### PR DESCRIPTION
Specifically, adds info on:

  1. git tag (if HEAD is tagged; otherwise "N/A")
  2. git branch (usually "master", but can be feature branches on
     e.g. staging)

Hopefully this'll be more immediately useful than a simple list of the
commits, as we have now. The list of commits is preserved in these
changes.

Refs https://github.com/freedomofpress/infrastructure/issues/2305
Implementation ported from https://github.com/freedomofpress/securedrop.org/pull/663


### Testing
If you want to review locally, run `docker-compose up --build`, then navigate to http://localhost:8000/admin/version/ . Examples of the before/after formatting can be found in https://github.com/freedomofpress/securedrop.org/pull/663