### PR TITLE
Uses exec in container entrypoint

### DIFF
--- a/docker/DevDjangoDockerfile
+++ b/docker/DevDjangoDockerfile
@@ -35,4 +35,4 @@ RUN  mkdir /deploy && \
 EXPOSE 8000
 USER gcorn
 
-CMD django-start.sh
+CMD ["/usr/local/bin/django-start.sh"]

--- a/docker/ProdDjangoDockerfile
+++ b/docker/ProdDjangoDockerfile
@@ -77,4 +77,4 @@ RUN /django/scripts/django-collect-static.sh
 EXPOSE 8000
 USER gcorn
 
-CMD django-start.sh
+CMD ["/usr/local/bin/django-start.sh"]

--- a/docker/django-start.sh
+++ b/docker/django-start.sh
@@ -29,9 +29,9 @@ django_start() {
     fi
     if [ "${DEPLOY_ENV}" == "dev" ]; then
         ./scripts/version-file.sh
-        ./manage.py runserver 0.0.0.0:8000
+        exec ./manage.py runserver 0.0.0.0:8000
     else
-        gunicorn -c /etc/gunicorn/gunicorn.py securethenews.wsgi
+        exec gunicorn -c /etc/gunicorn/gunicorn.py securethenews.wsgi
     fi
 }
 


### PR DESCRIPTION
The container image should report its process as `gunicorn` in prod
contexts, so that the application gracefully terminates when it receives
a SIGTERM from the managing process [0]. Without using `exec`, the container
reports that sh is the active process (sh -> bash -> gunicorn), so a
SIGTERM to sh results in SIGKILL on the children.

[0] https://docs.gunicorn.org/en/stable/signals.html