### PR TITLE
dev node base image isn't used AS anything, remove

### DIFF
--- a/docker/DevNodeDockerfile
+++ b/docker/DevNodeDockerfile
@@ -1,5 +1,5 @@
 # sha256 as of 2020-06-30 for node:10-alpine
-FROM node@sha256:bafda8e474ba8973f146cb3fc2d531cf7fb7fec73ef4ca04aa38f26db520a883 AS node-assets
+FROM node@sha256:bafda8e474ba8973f146cb3fc2d531cf7fb7fec73ef4ca04aa38f26db520a883
 
 # Install npm, making output less verbose
 ARG NPM_VER=6.13.7


### PR DESCRIPTION
Slight cleanup from #241. This line was copied and pasted from the prod dockerfile, which does use a multistage build and needs `AS node-assets` to give it a name. The dev setup does not, so having it there has no effect and might be confusing.