### PR TITLE
Fix safety failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 	@for req_file in `find . -type f -name '*requirements.txt'`; do \
 		echo "Checking file $$req_file" \
 		&& safety check --ignore 36351 --ignore 36546 --ignore 36533 --ignore 36534\
+		--ignore=38449 --ignore=38450 --ignore=38451 --ignore=38452\
 		--ignore 36541 --ignore 38197 --ignore 38198 --full-report -r $$req_file \
 		&& echo -e '\n' \
 		|| exit 1; \

--- a/package-lock.json
+++ b/package-lock.json
@@ -5116,9 +5116,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.17.tgz",
+      "integrity": "sha512-/B2DjOphAoqi5BX4Gg2oh4UR0Gy/A7xYAMh3aSECEKzwS3eCDEpS0Cals1Ktvxwlal3bBJNc+5W9kNIcADdw5Q==",
       "dev": true
     },
     "lodash.memoize": {

--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -460,9 +460,9 @@ requests==2.23.0 \
     --hash=sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee \
     --hash=sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6 \
     # via -r requirements.txt, django-mailgun, google-api-core, pshtt, pytablereader, requests-cache, wagtail
-rsa==3.4.2 \
-    --hash=sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5 \
-    --hash=sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd \
+rsa==4.6 \
+    --hash=sha256:109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa \
+    --hash=sha256:6166864e23d6b5195a5cfed6cd9fed0fe774e226d8f854fcb23b7bbef0350233 \
     # via -r requirements.txt, google-auth
 s3transfer==0.1.13 \
     --hash=sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1 \

--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -177,9 +177,9 @@ django-webpack-loader==0.6.0 \
     --hash=sha256:60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520 \
     --hash=sha256:970b968c2a8975fb7eff56a3bab5d0d90d396740852d1e0c50c5cfe2b824199a \
     # via -r requirements.txt
-django==2.2.12 \
-    --hash=sha256:69897097095f336d5aeef45b4103dceae51c00afa6d3ae198a2a18e519791b7a \
-    --hash=sha256:6ecd229e1815d4fc5240fc98f1cca78c41e7a8cd3e3f2eefadc4735031077916 \
+django==2.2.14 \
+    --hash=sha256:edf0ecf6657713b0435b6757e6069466925cae70d634a3283c96b80c01e06191 \
+    --hash=sha256:f2250bd35d0f6c23e930c544629934144e5dd39a4c06092e1050c731c1712ba8 \
     # via -r requirements.txt, django-analytical, django-cors-headers, django-filter, django-logging-json, django-storages, django-taggit, django-treebeard, wagtail
 djangorestframework==3.9.1 \
     --hash=sha256:79c6efbb2514bc50cf25906d7c0a5cfead714c7af667ff4bd110312cd380ae66 \

--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -198,6 +198,7 @@ dominate==2.3.1 \
     # via -r requirements.txt, pytablewriter
 draftjs-exporter==2.1.7 \
     --hash=sha256:5839cbc29d7bce2fb99837a404ca40c3a07313f2a20e2700de7ad6aa9a9a18fb \
+    --hash=sha256:d415a9964690a2cddb66a31ef32dd46c277e9b80434b94e39e3043188ed83e33 \
     # via -r requirements.txt, wagtail
 elasticsearch==5.4.0 \
     --hash=sha256:8f02d626cff98befd298ffb1d19d8e519643d86d3aa27f6d7388566ec4ba48ee \

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -157,6 +157,7 @@ dominate==2.3.1 \
     # via pytablewriter
 draftjs-exporter==2.1.7 \
     --hash=sha256:5839cbc29d7bce2fb99837a404ca40c3a07313f2a20e2700de7ad6aa9a9a18fb \
+    --hash=sha256:d415a9964690a2cddb66a31ef32dd46c277e9b80434b94e39e3043188ed83e33 \
     # via wagtail
 elasticsearch==5.4.0 \
     --hash=sha256:8f02d626cff98befd298ffb1d19d8e519643d86d3aa27f6d7388566ec4ba48ee \

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -136,9 +136,9 @@ django-webpack-loader==0.6.0 \
     --hash=sha256:60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520 \
     --hash=sha256:970b968c2a8975fb7eff56a3bab5d0d90d396740852d1e0c50c5cfe2b824199a \
     # via -r requirements.in
-django==2.2.12 \
-    --hash=sha256:69897097095f336d5aeef45b4103dceae51c00afa6d3ae198a2a18e519791b7a \
-    --hash=sha256:6ecd229e1815d4fc5240fc98f1cca78c41e7a8cd3e3f2eefadc4735031077916 \
+django==2.2.14 \
+    --hash=sha256:edf0ecf6657713b0435b6757e6069466925cae70d634a3283c96b80c01e06191 \
+    --hash=sha256:f2250bd35d0f6c23e930c544629934144e5dd39a4c06092e1050c731c1712ba8 \
     # via -r requirements.in, django-analytical, django-cors-headers, django-filter, django-logging-json, django-storages, django-taggit, django-treebeard, wagtail
 djangorestframework==3.9.1 \
     --hash=sha256:79c6efbb2514bc50cf25906d7c0a5cfead714c7af667ff4bd110312cd380ae66 \

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -379,9 +379,9 @@ requests==2.23.0 \
     --hash=sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee \
     --hash=sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6 \
     # via django-mailgun, google-api-core, pshtt, pytablereader, requests-cache, wagtail
-rsa==3.4.2 \
-    --hash=sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5 \
-    --hash=sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd \
+rsa==4.6 \
+    --hash=sha256:109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa \
+    --hash=sha256:6166864e23d6b5195a5cfed6cd9fed0fe774e226d8f854fcb23b7bbef0350233 \
     # via google-auth
 s3transfer==0.1.13 \
     --hash=sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1 \


### PR DESCRIPTION
This pull request updates Django to 2.2.14 to fix some security vulnerabilities and also instructs safety to ignore several vulnerabilities in the Pillow library until the wagtail LTS branch relaxes its dependency on the pillow 6.2.x branch, which is no longer supported. 

I also updated the `rsa` package to the latest version, fixing a vulnerability documented at [CVE-2020-13757](https://nvd.nist.gov/vuln/detail/CVE-2020-13757).

Also added a new hash for the draftjs-exporter package, as it was published in wheel form recently (see commit for more info).