### PR TITLE
Include requirements.in not requirements.txt

### DIFF
--- a/securethenews/dev-requirements.in
+++ b/securethenews/dev-requirements.in
@@ -1,3 +1,3 @@
--r requirements.txt
+-r requirements.in
 coverage
 ipdb


### PR DESCRIPTION
I was attempting to test out upgrading some dependencies in my dev env, and ran into a problem: Because `dev-requirements.in` includes `requirements.txt` via `-r`, it pulls in whatever versions and hashes were pinned by the last update of *production* dependencies. If we want to update something, this will cause conflicts.

I *think* that including `requirements.in` instead will attempt to resolve all the same dependencies as were resolved for prod, but be more flexible in allowing one of them to be upgraded by an upgraded package depending on it. Does this seem reasonable?