### PR TITLE
Update lodash for security advisory 1523

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5116,9 +5116,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.17.tgz",
-      "integrity": "sha512-/B2DjOphAoqi5BX4Gg2oh4UR0Gy/A7xYAMh3aSECEKzwS3eCDEpS0Cals1Ktvxwlal3bBJNc+5W9kNIcADdw5Q==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.memoize": {


### PR DESCRIPTION
From npm audit:

```                                                                                                                                                       
LOW: 1523 - Prototype Pollution                                                                                                                               
                                                                                                                                                              
Versions of `lodash` prior to 4.17.19 are vulnerable to Prototype Pollution.  The function `zipObjectDeep` allows a malicious user to modify the prototype of 
`Object` if the property identifiers are user-supplied. Being affected by this issue requires zipping objects based on user-provided property arrays.         
                                                                                                                                                              
This vulnerability causes the addition or modification of an existing property that will exist on all objects and may lead to Denial of Service or Code       
Execution under specific circumstances.                                                                                                                       
                                                                                                                                                              
Upgrade to version 4.17.19 or later.                                                                                                                          

- Version:   4.17.17
- Path:      @babel/core>@babel/generator>@babel/types>lodash
- More info: https://npmjs.com/advisories/1523
```