### PR TITLE
No default UID, because dev env and CI both must supply it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DIR := ${CURDIR}
 WHOAMI := ${USER}
 RAND_PORT := ${RAND_PORT}
-DOCKER_COMPOSE_UID := 1001 # avoid collision with node image's predefined user
+HOST_UID := $(shell id -u)
 GIT_REV := $(shell git rev-parse HEAD | cut -c1-10)
 GIT_BR := $(shell git rev-parse --abbrev-ref HEAD)
 STN_IMAGE := quay.io/freedomofpress/securethenews
@@ -104,7 +104,7 @@ dev-go: dev-init ## Runs development environment
 
 .PHONY: dev-init
 dev-init: ## pipe ENVs into docker-compose, prevents need of wrapper script
-	echo UID=$(DOCKER_COMPOSE_UID) > .env
+	echo UID=$(HOST_UID) > .env
 
 .PHONY: app-tests-dev
 app-tests-dev: ## Run development tests (dev)

--- a/docker/DevDjangoDockerfile
+++ b/docker/DevDjangoDockerfile
@@ -22,7 +22,9 @@ RUN apt-get update && \
 COPY docker/django-start.sh /usr/local/bin
 RUN  chmod +x /usr/local/bin/django-start.sh
 
-ARG USERID=1000
+# docker-compose will pass in the host UID here so that the volume
+# permissions are correct
+ARG USERID
 RUN adduser --disabled-password --gecos "" --uid "${USERID}" gcorn
 
 RUN paxctl -cm /usr/local/bin/python

--- a/docker/DevDjangoDockerfile
+++ b/docker/DevDjangoDockerfile
@@ -22,10 +22,10 @@ RUN apt-get update && \
 COPY docker/django-start.sh /usr/local/bin
 RUN  chmod +x /usr/local/bin/django-start.sh
 
-# docker-compose will pass in the host UID here so that the volume
+# docker-compose must pass in the host UID here so that the volume
 # permissions are correct
 ARG USERID
-RUN adduser --disabled-password --gecos "" --uid "${USERID}" gcorn
+RUN adduser --disabled-password --gecos "" --uid "${USERID?USERID must be supplied}" gcorn
 
 RUN paxctl -cm /usr/local/bin/python
 COPY securethenews/dev-requirements.txt /requirements.txt

--- a/docker/DevNodeDockerfile
+++ b/docker/DevNodeDockerfile
@@ -1,5 +1,5 @@
 # sha256 as of 2020-06-30 for node:10-alpine
-FROM node@sha256:bafda8e474ba8973f146cb3fc2d531cf7fb7fec73ef4ca04aa38f26db520a883 AS node-assets
+FROM node@sha256:bafda8e474ba8973f146cb3fc2d531cf7fb7fec73ef4ca04aa38f26db520a883
 
 # Install npm, making output less verbose
 ARG NPM_VER=6.13.7

--- a/docker/DevNodeDockerfile
+++ b/docker/DevNodeDockerfile
@@ -10,10 +10,13 @@ RUN npm install npm@${NPM_VER} -g
 # https://github.com/webpack/webpack-dev-server/issues/128
 ENV UV_THREADPOOL_SIZE 128
 
-ARG USERID=1000
-# node image uses BusyBox adduser, so short options only
-# The image already has a 'node' user
-RUN adduser -D -g "" -u "${USERID}" docker_user
+# docker-compose must pass in the host UID here so that the volume
+# permissions are correct
+ARG USERID
+# The node image uses BusyBox adduser, so short options here only. The
+# image already has a 'node' user. If it matches our UID, just use it,
+# but if it doesn't, create a user with a different name.
+RUN getent passwd "${USERID?USERID must be supplied}" || adduser -D -g "" -u "${USERID}" stn_node
 
 # Oddly, node-sass requires both python and make to build bindings
 RUN apk add --no-cache paxctl python make g++

--- a/docker/ProdDjangoDockerfile
+++ b/docker/ProdDjangoDockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && \
 COPY docker/django-start.sh /usr/local/bin
 RUN  chmod +x /usr/local/bin/django-start.sh
 
-ARG USERID=1000
+# Infra will supply this in CI, because it needs to match Kubernetes
+ARG USERID
 RUN adduser --disabled-password --gecos "" --uid "${USERID}" gcorn
 
 LABEL MAINTAINER="Freedom of the Press Foundation"

--- a/docker/ProdDjangoDockerfile
+++ b/docker/ProdDjangoDockerfile
@@ -43,7 +43,7 @@ RUN  chmod +x /usr/local/bin/django-start.sh
 
 # Infra will supply this in CI, because it needs to match Kubernetes
 ARG USERID
-RUN adduser --disabled-password --gecos "" --uid "${USERID}" gcorn
+RUN adduser --disabled-password --gecos "" --uid "${USERID?USERID must be supplied}" gcorn
 
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="securethenews"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5116,9 +5116,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.17.tgz",
-      "integrity": "sha512-/B2DjOphAoqi5BX4Gg2oh4UR0Gy/A7xYAMh3aSECEKzwS3eCDEpS0Cals1Ktvxwlal3bBJNc+5W9kNIcADdw5Q==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.memoize": {

--- a/prod-docker-compose.yaml
+++ b/prod-docker-compose.yaml
@@ -22,6 +22,10 @@ services:
     build:
       context: .
       dockerfile: docker/ProdDjangoDockerfile
+      args:
+        # Ensure that this does *not* depend on the host env, and the
+        # production CI and deployment can set it to whatever
+        USERID: 12345
     image: quay.io/freedomofpress/securethenews
     read_only: true
     environment:


### PR DESCRIPTION
Over in Kubernetes we want to specify the container user as a UID for security-hardening reasons. Right now, this is done by copying the UID set in the app's Dockerfile to the manifest.

Infra should actually own setting what that is in production, so let's *not* default the UID, and fail the build if it isn't passed. This means we can DRY up the situation here where we have a default arg in the Dockerfiles but also pass it through `docker-compose` from `make`. The situation with `docker-compose` is actually very similar, because it *has* to pass in the UID from the environment so that volume sharing will work. There isn't a default that will work for all dev workstation setups. So, have that be the one place it gets set.

Over in infra land we do still set the production UID in two places, but that's our problem now :). I adjusted prod-docker-compose.yml to pass in a UID that is unlikely to exist on your workstation to validate that production will be able to set it.

Finally, if the UID in dev conflicts with the recently-updated `node` image, go ahead and use the predefined user instead of failing the dev image build.

This pulls in https://github.com/freedomofpress/securethenews/pull/244 so I'm closing that.