### PR TITLE
flake8: \. is not a valid escape

### DIFF
--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -220,7 +220,7 @@ WEBPACK_LOADER = {  # noqa: W605
                                    'client/build/webpack-stats.json'),
         'POLL_INTERVAL': 0.1,
         'TIMEOUT': None,
-        'IGNORE': ['.+\.hot-update.js', '.+\.map']
+        'IGNORE': [r'.+\.hot-update.js', r'.+\.map']
     }
 }
 


### PR DESCRIPTION
Once I was finally able to get CI running with #255, I found an actual lint! I think we meant a raw string here since this is a regex.