### PR TITLE
Fix typo in version-file.sh

### DIFF
--- a/scripts/version-file.sh
+++ b/scripts/version-file.sh
@@ -13,7 +13,7 @@ cat /dev/null > "${DEPLOY_FILE}"
 echo -e "## GIT INFO #####\n" >> "${DEPLOY_FILE}"
 
 git_branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo "N/A")"
-echo -e "git branch: ${git_branch_info}\n" >> "${DEPLOY_FILE}"
+echo -e "git branch: ${git_branch}\n" >> "${DEPLOY_FILE}"
 
 case "$git_branch" in
     N/A)
@@ -24,6 +24,7 @@ case "$git_branch" in
         echo -e "last release and commits since: $(git describe)" >> "${DEPLOY_FILE}";;
 esac
 
+echo >> "${DEPLOY_FILE}"
 git log -5 --oneline >> "${DEPLOY_FILE}"
 
 echo -e "\n## PYTHON INFO #####" >> "${DEPLOY_FILE}"


### PR DESCRIPTION
Missed this in https://github.com/freedomofpress/securethenews/pull/250 somehow. Because the branch var wasn't set, the release info wasn't generated: https://staging.securethe.news/admin/version