### PR TITLE
Add the onion service URL to footer of home page

### DIFF
--- a/client/src/styles/_footer.scss
+++ b/client/src/styles/_footer.scss
@@ -31,4 +31,13 @@
 .fine-print {
   font-size: 12px;
   margin-bottom: $spacingUnit;
+  
+  a {
+    color: $textGray;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }

--- a/client/src/styles/_footer.scss
+++ b/client/src/styles/_footer.scss
@@ -30,4 +30,5 @@
 
 .fine-print {
   font-size: 12px;
+  margin-bottom: $spacingUnit;
 }

--- a/home/models.py
+++ b/home/models.py
@@ -4,6 +4,7 @@ import json
 import math
 
 from django.db import models
+from django.conf import settings
 
 from modelcluster.fields import ParentalKey
 from wagtail.contrib.table_block.blocks import TableBlock
@@ -64,6 +65,10 @@ class HomePage(Page):
         """Special Wagtail method used to add more variables to the
         template context."""
         context = super(HomePage, self).get_context(request)
+
+        # Our onion service
+        if settings.ONION_HOSTNAME is not None:
+            context['onion_hostname'] = settings.ONION_HOSTNAME
 
         # Compute summary statistics
         sites = Site.scanned.all()

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -136,3 +136,11 @@
     var STNsiteData = {{ sites_json|safe }};
   </script>
 {% endblock %}
+
+{% block onion_service %}
+  {% if onion_hostname %}
+  <p class="fine-print">
+    Tor address: <a href="http://{{ onion_hostname }}">{{ onion_hostname }}</a>
+  </p>
+  {% endif %}
+{% endblock %}

--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -112,6 +112,10 @@ SECURE_HSTS_PRELOAD = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 
+# Make the deployment's onion service name available to templates
+ONION_HOSTNAME = os.environ.get('DJANGO_ONION_HOSTNAME')
+
+
 ROOT_URLCONF = 'securethenews.urls'
 
 TEMPLATES = [

--- a/securethenews/templates/base.html
+++ b/securethenews/templates/base.html
@@ -80,6 +80,7 @@
               <p class="fine-print">
                 This work is licensed under a Creative Commons Attribution 4.0 International License
               </p>
+              {% block onion_service %}{% endblock %}
             </div>
           </section>
         {% endblock %}


### PR DESCRIPTION
With https://github.com/freedomofpress/k8s-configs/pull/135, we will be ready for the onion service URL to be advertised. In addition to an `Onion-Location` header, I thought it'd be nice to have the URL in the footer as we do on some other sites in case the ".onion available" URL bar thing doesn't appear or isn't noticed by the user.

Leaving this as a draft since the Tor deployment change is not actually live yet, but wanted to give enough time for review. I'm not very good with CSS but this seemed to look OK in my dev environment (I tested by adding the `DJANGO_ONION_HOSTNAME` env var that exists in production to my docker-compose.yaml).