### PR TITLE
copy: link out to onion service docs on individual site pages

### DIFF
--- a/sites/templates/sites/site.html
+++ b/sites/templates/sites/site.html
@@ -50,9 +50,9 @@
         </div>
         <div class="rating-section-body">
           {% if scan.onion_available %}
-            Provides an onion service.
+            Provides an <a href="https://community.torproject.org/onion-services/">onion service</a>.
           {% else %}
-            Does not provide an onion service.
+            Does not provide an <a href="https://community.torproject.org/onion-services/">onion service</a>.
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
Minor change just to copy not updatable via Wagtail (to add a link to onion service documentation on the individual site pages)