### PR TITLE
feat(leaderboard): enable sort by onion service availabilty

### DIFF
--- a/client/src/leaderboardtemplate.jade
+++ b/client/src/leaderboardtemplate.jade
@@ -23,8 +23,10 @@ mixin check(condition)
             .inline-block.align-middle HSTS
           th.desktop-only
             .inline-block.align-middle HSTS Preloaded
-          th.desktop-only
+          th.sort-control(data-sort-key='onion_available')
             .inline-block.align-middle Available Over Onion Services
+            if state.orderBy == 'onion_available'
+              i.sort-icon.fa(class=iconClass)
           th.sort-control(data-sort-key='score')
             .inline-block.align-middle Grade
             if state.orderBy == 'score'


### PR DESCRIPTION
In the full leaderboard view one can sort by grade (which really sorts by score) but not other attributes - this PR has a tiny change to allow one to sort by onion service availability. I didn't extend this to other fields for now (but it's a small change so can do this in this PR if folks want).

Towards #277 since someone suggested this on twitter today - https://twitter.com/kura_a98/status/1313570923660955648

Screenshot: 

![Screen Shot 2020-10-06 at 4 42 29 PM](https://user-images.githubusercontent.com/7832803/95257898-fe9b4200-07f2-11eb-8450-98984afc7e58.png)
