### PR TITLE
Improve ignore handling in safety script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,8 @@ pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading
 
 .PHONY: safety
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities
-	@for req_file in `find . -type f -name '*requirements.txt'`; do \
-		echo "Checking file $$req_file" \
-		&& safety check --ignore=38197\
-		--full-report -r $$req_file \
-		&& echo -e '\n' \
-		|| exit 1; \
-	done
+# Upgrade safety to ensure we are using the latest version.
+	pip install --upgrade safety && ./scripts/safety_check.py
 
 .PHONY: clean
 clean: ## Removes temporary gitignored development artifacts

--- a/project.json
+++ b/project.json
@@ -1,0 +1,5 @@
+{
+    "variables": {
+        "SAFETY_IGNORE_IDS": ["38197"]
+    }
+}

--- a/scripts/safety_check.py
+++ b/scripts/safety_check.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import json
+import traceback
+import glob
+import subprocess
+import sys
+import pathlib
+
+
+def check_full_report(ids_to_ignore=[]):
+    """Runs `safety` on all requirements files, outputs the full report
+    for each.  Exits with a success code (0) if all the checks also
+    executed with success, and exits with a failure code (1)
+    otherwise.  Intended to be run in a CI context where the exit code
+    of this command alone determines the pass/fail status of the
+    overall check.
+
+    """
+    success = True
+    command = ['safety', 'check', '--full-report']
+    for ignored_id in ids_to_ignore:
+        command.extend(['-i', ignored_id])
+    for filename in glob.glob('**/*requirements.txt', recursive=True):
+        print('Checking {}'.format(filename))
+        result = subprocess.run(command + ['-r', filename])
+        if result.returncode != 0:
+            success = False
+    return 0 if success else 1
+
+
+if __name__ == '__main__':
+    project_path = pathlib.Path(__file__).parent.parent / "project.json"
+
+    project = json.loads(project_path.read_text())
+
+    try:
+        sys.exit(
+            check_full_report(project['variables']['SAFETY_IGNORE_IDS'])
+        )
+    except Exception:
+        sys.stderr.write(traceback.format_exc())
+        sys.exit(1)


### PR DESCRIPTION
This pull request creates a new script that's in charge of running the safety check, where previously this logic was stored in the Makefile.  The idea is to have this this script be a very thin wrapper around `safety` itself, with the main purpose being to load the appropriate IDs to ignore from a project-level JSON config file.  The JSON data can be shared with the fpf-www-projects check and processed to separate ignores and failures there, rather than here, where this script only needs to output pass or fail for CI runs on feature branches.

Refs https://github.com/freedomofpress/fpf-www-projects/issues/123