### PR TITLE
Adds CSP rules to securethenews

### DIFF
--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -147,6 +147,10 @@ django-crispy-forms==1.9.2 \
     --hash=sha256:888bb316db89b60050a42ec35080facb361d823eec38010ccb0702f45642d3b8 \
     --hash=sha256:f2f1e0fbb458851636447cfb6be1a611b40c8ac9e41a74ba923011378670b43b \
     # via -r requirements.in
+django-csp==3.7 \
+    --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
+    --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727 \
+    # via -r requirements.in
 django-filter==2.4.0 \
     --hash=sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06 \
     --hash=sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1 \

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -3,6 +3,7 @@ Django>=2.2.12,<2.3
 django-analytical>=2.5,<2.6
 django-cors-headers>=3.0.0
 django-crispy-forms>=1.7.2
+django-csp
 django-filter>=2.1.0
 django-mailgun
 django-storages[boto3, google]>=1.7 # aws s3, google storage asset management

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -103,6 +103,10 @@ django-crispy-forms==1.9.2 \
     --hash=sha256:888bb316db89b60050a42ec35080facb361d823eec38010ccb0702f45642d3b8 \
     --hash=sha256:f2f1e0fbb458851636447cfb6be1a611b40c8ac9e41a74ba923011378670b43b \
     # via -r requirements.in
+django-csp==3.7 \
+    --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
+    --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727 \
+    # via -r requirements.in
 django-filter==2.4.0 \
     --hash=sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06 \
     --hash=sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1 \

--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -274,24 +274,27 @@ CSP_STYLE_SRC = (
 CSP_FRAME_SRC = ("'self'",)
 CSP_CONNECT_SRC = ("'self'",)
 
+# This will be used to evaluate Google Storage media support in staging
+GS_CUSTOM_ENDPOINT = os.environ.get(
+    "GS_CUSTOM_ENDPOINT",
+    "https://media.securethe.news"
+)
+
 # Need to be lists for now so that CSP configuration can add to them.
 # This should be reverted after testing.
-CSP_IMG_SRC = [
+CSP_IMG_SRC = (
     "'self'",
     "analytics.freedom.press",
-]
-CSP_OBJECT_SRC = ["'self'"]
-CSP_MEDIA_SRC = ["'self'"]
-
-# This will be used to evaluate Google Storage media support in staging
-if os.environ.get("DJANGO_CSP_IMG_HOSTS"):
-    CSP_IMG_SRC.extend(os.environ["DJANGO_CSP_IMG_HOSTS"].split())
-    CSP_MEDIA_SRC.extend(os.environ["DJANGO_CSP_IMG_HOSTS"].split())
-
-# There are also PDF <embeds> in some news posts, so rather than adding to
-# default-src, set an explicit object-source
-if os.environ.get("DJANGO_CSP_OBJ_HOSTS"):
-    CSP_OBJECT_SRC.extend(os.environ["DJANGO_CSP_OBJ_HOSTS"].split())
+    GS_CUSTOM_ENDPOINT,
+)
+CSP_OBJECT_SRC = (
+    "'self'",
+    GS_CUSTOM_ENDPOINT,
+)
+CSP_MEDIA_SRC = (
+    "'self'",
+    GS_CUSTOM_ENDPOINT,
+)
 
 # Report URI must be a string, not a tuple.
 CSP_REPORT_URI = os.environ.get(

--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -260,7 +260,10 @@ CSP_SCRIPT_SRC = (
     "'sha256-hk71/yNgJt0WwDMKIEPWJnms3ftGXFupYCx2GTlIB68='",
     # inline code for admin login page
     "'sha256-k0JY2oqoByUSPWtC/jMqxOh8d97885BXv2fPJ5gKeEg='",
-    "'sha256-rpjW8Yb1oj3Jg4It9QBspH3wBoSTwndEFmse3sPn8Qw='"
+    "'sha256-rpjW8Yb1oj3Jg4It9QBspH3wBoSTwndEFmse3sPn8Qw='",
+    # needed for piwik inline
+    "'sha256-Ujy9USzNCsaDKHVACggM1NqXbQJ2ljlpMX9U4g2d5d0='",
+    "analytics.freedom.press",
 )
 CSP_STYLE_SRC = (
     "'self'",
@@ -274,7 +277,8 @@ CSP_CONNECT_SRC = ("'self'",)
 # Need to be lists for now so that CSP configuration can add to them.
 # This should be reverted after testing.
 CSP_IMG_SRC = [
-    "'self'"
+    "'self'",
+    "analytics.freedom.press",
 ]
 CSP_OBJECT_SRC = ["'self'"]
 CSP_MEDIA_SRC = ["'self'"]

--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -81,7 +81,10 @@ MIDDLEWARE = [
 
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
-    'django_logging.middleware.DjangoLoggingMiddleware'
+    'django_logging.middleware.DjangoLoggingMiddleware',
+
+    # Middleware for content security policy
+    'csp.middleware.CSPMiddleware',
 ]
 
 if bool(os.environ.get('DJANGO_WHITENOISE', False)):
@@ -242,3 +245,52 @@ if os.environ.get('DJANGO_XMLTEST_OUTPUT', 'no').lower() in ['yes', 'true']:
     TEST_OUTPUT_FILE_NAME = "app-tests.xml"
     TEST_OUTPUT_DESCRIPTIONS = True
     TEST_OUTPUT_VERBOSE = 2
+
+# Content Security Policy
+# script:
+# unsafe-eval for client/build/build.js
+# style:
+# #2 and #3 hashes needed for inline style for modernizr on admin page
+# #4 needed for wagtail admin
+CSP_DEFAULT_SRC = ("'self'",)
+CSP_SCRIPT_SRC = (
+    "'self'",
+    "'unsafe-eval'",
+    # inline code to load STNsiteData
+    "'sha256-hk71/yNgJt0WwDMKIEPWJnms3ftGXFupYCx2GTlIB68='",
+    # inline code for admin login page
+    "'sha256-k0JY2oqoByUSPWtC/jMqxOh8d97885BXv2fPJ5gKeEg='",
+    "'sha256-rpjW8Yb1oj3Jg4It9QBspH3wBoSTwndEFmse3sPn8Qw='"
+)
+CSP_STYLE_SRC = (
+    "'self'",
+    "'sha256-CwE3Bg0VYQOIdNAkbB/Btdkhul49qZuwgNCMPgNY5zw='",
+    "'sha256-MZKTI0Eg1N13tshpFaVW65co/LeICXq4hyVx6GWVlK0='",
+    "'sha256-aqNNdDLnnrDOnTNdkJpYlAxKVJtLt9CtFLklmInuUAE='",
+)
+CSP_FRAME_SRC = ("'self'",)
+CSP_CONNECT_SRC = ("'self'",)
+
+# Need to be lists for now so that CSP configuration can add to them.
+# This should be reverted after testing.
+CSP_IMG_SRC = [
+    "'self'"
+]
+CSP_OBJECT_SRC = ["'self'"]
+CSP_MEDIA_SRC = ["'self'"]
+
+# This will be used to evaluate Google Storage media support in staging
+if os.environ.get("DJANGO_CSP_IMG_HOSTS"):
+    CSP_IMG_SRC.extend(os.environ["DJANGO_CSP_IMG_HOSTS"].split())
+    CSP_MEDIA_SRC.extend(os.environ["DJANGO_CSP_IMG_HOSTS"].split())
+
+# There are also PDF <embeds> in some news posts, so rather than adding to
+# default-src, set an explicit object-source
+if os.environ.get("DJANGO_CSP_OBJ_HOSTS"):
+    CSP_OBJECT_SRC.extend(os.environ["DJANGO_CSP_OBJ_HOSTS"].split())
+
+# Report URI must be a string, not a tuple.
+CSP_REPORT_URI = os.environ.get(
+    'DJANGO_CSP_REPORT_URI',
+    'https://freedomofpress.report-uri.com/r/d/csp/enforce'
+)


### PR DESCRIPTION
Few things to note:
- Added sha-256 for all the unsafe-inline restrictions.
- Sadly had to add unsafe-eval because build.js uses it for webpack.
- The gravatar URL in admin doesn't work, which is consistent with freedom.press (though securedrop seems to exclude CSP altogether in `/admin/` path)
- I haven't included `analytics.freedom.press` in any of the rules, neither piwik sha256 because even though I see PIWIK_ID mentioned in production.py, I don't see them in the HTML loaded for the website. Is it being used somewhere? Then I will need to add those to the rules.

Apart from that, everything should mostly be working.

Fixes #284 