### PR TITLE
Sort leaderboard by name

### DIFF
--- a/client/src/leaderboard.js
+++ b/client/src/leaderboard.js
@@ -1,8 +1,17 @@
 import Backbone from 'backbone'
 import _ from 'underscore'
-import $ from 'jquery'
+import $, { get } from 'jquery'
 import Sites from './sites'
 import template from './leaderboardtemplate.jade'
+import orderBy from 'lodash/orderBy'
+
+// Return the name attribute of an object with beginning articles (a,
+// an, the) removed and converted to lower-case for sorting in a more
+// expected, human-readable way.
+const sortableName = (obj) => {
+  return obj.name.replace(/^(an?|the)\s*/i, '').toLowerCase();
+}
+
 
 export default Backbone.View.extend({
   initialize(options) {
@@ -56,17 +65,11 @@ export default Backbone.View.extend({
         || site.domain.toLowerCase().indexOf(this.state.get('searchString')) !== -1;
     });
 
-    models = _.sortBy(models, this.state.get('orderBy'))
-
-    if (this.state.get('orderBy') == 'https_available') {
-      models = _.sortBy(models, function(item) {
-        return item.valid_https && !item.downgrades_https
-      })
+    let orderByIdentity = this.state.get('orderBy')
+    if (orderByIdentity == 'https_available') {
+      orderByIdentity = (item) => item.valid_https && !item.downgrades_https
     }
-
-    if (this.state.get('order') == 'desc') {
-      models = models.reverse();
-    }
+    models = orderBy(models, [orderByIdentity, sortableName], [this.state.get('order'), 'asc']);
 
     if (this.options.limit !== null) {
       models = models.slice(0, this.options.limit);

--- a/client/src/leaderboard.js
+++ b/client/src/leaderboard.js
@@ -9,7 +9,7 @@ import orderBy from 'lodash/orderBy'
 // an, the) removed and converted to lower-case for sorting in a more
 // expected, human-readable way.
 const sortableName = (obj) => {
-  return obj.name.replace(/^(an?|the)\s*/i, '').toLowerCase();
+  return obj.name.replace(/^(an?|the)\s+/i, '').toLowerCase();
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5110,10 +5110,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-      "dev": true
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "file-loader": "^4.0.0",
     "font-awesome": "^4.7.0",
     "jquery": "^3.5.0",
+    "lodash": "^4.17.20",
     "source-sans-pro": "^2.45.0",
     "underscore": "^1.8.3"
   }


### PR DESCRIPTION
Fixes #278 

This pull request changes the sorting of the leaderboard to sort by news organization name after sorting by the score.

I've chosen to add `lodash` as a dependency here since its sorting capabilities are more flexible and more in line with the kind of sorting we want to perform here. This doesn't even really add that much to the "weight" of our JS. According to [the documentation](https://lodash.com/per-method-packages), if we just import the single function we want, it will only even add the small subset of lodash code that we're using into the final bundle.