### PR TITLE
Adds nonce to handle inline script in regional leaderboards

### DIFF
--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -274,6 +274,9 @@ CSP_STYLE_SRC = (
 CSP_FRAME_SRC = ("'self'",)
 CSP_CONNECT_SRC = ("'self'",)
 
+# Nonce needed for region based STNsiteData
+CSP_INCLUDE_NONCE_IN = ["script-src"]
+
 # This will be used to evaluate Google Storage media support in staging
 GS_CUSTOM_ENDPOINT = os.environ.get(
     "GS_CUSTOM_ENDPOINT",

--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -249,33 +249,24 @@ if os.environ.get('DJANGO_XMLTEST_OUTPUT', 'no').lower() in ['yes', 'true']:
 # Content Security Policy
 # script:
 # unsafe-eval for client/build/build.js
+# unsafe-inline for admin
 # style:
+# unsafe-inline needed for wagtail admin inline styles
 # #2 and #3 hashes needed for inline style for modernizr on admin page
 # #4 needed for wagtail admin
 CSP_DEFAULT_SRC = ("'self'",)
 CSP_SCRIPT_SRC = (
     "'self'",
     "'unsafe-eval'",
-    # inline code to load STNsiteData
-    "'sha256-hk71/yNgJt0WwDMKIEPWJnms3ftGXFupYCx2GTlIB68='",
-    # inline code for admin login page
-    "'sha256-k0JY2oqoByUSPWtC/jMqxOh8d97885BXv2fPJ5gKeEg='",
-    "'sha256-rpjW8Yb1oj3Jg4It9QBspH3wBoSTwndEFmse3sPn8Qw='",
-    # needed for piwik inline
-    "'sha256-Ujy9USzNCsaDKHVACggM1NqXbQJ2ljlpMX9U4g2d5d0='",
+    "'unsafe-inline'",
     "analytics.freedom.press",
 )
 CSP_STYLE_SRC = (
     "'self'",
-    "'sha256-CwE3Bg0VYQOIdNAkbB/Btdkhul49qZuwgNCMPgNY5zw='",
-    "'sha256-MZKTI0Eg1N13tshpFaVW65co/LeICXq4hyVx6GWVlK0='",
-    "'sha256-aqNNdDLnnrDOnTNdkJpYlAxKVJtLt9CtFLklmInuUAE='",
+    "'unsafe-inline'",
 )
 CSP_FRAME_SRC = ("'self'",)
 CSP_CONNECT_SRC = ("'self'",)
-
-# Nonce needed for region based STNsiteData
-CSP_INCLUDE_NONCE_IN = ["script-src"]
 
 # This will be used to evaluate Google Storage media support in staging
 GS_CUSTOM_ENDPOINT = os.environ.get(

--- a/sites/templates/sites/leaderboard.html
+++ b/sites/templates/sites/leaderboard.html
@@ -45,7 +45,7 @@
   </section>
 
   <!-- Dump the site data to be rendered client-side. -->
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{request.csp_nonce}}">
     var STNsiteData = {{ sites_json|safe }};
   </script>
 {% endblock %}

--- a/sites/templates/sites/leaderboard.html
+++ b/sites/templates/sites/leaderboard.html
@@ -45,7 +45,7 @@
   </section>
 
   <!-- Dump the site data to be rendered client-side. -->
-  <script type="text/javascript" nonce="{{request.csp_nonce}}">
+  <script type="text/javascript">
     var STNsiteData = {{ sites_json|safe }};
   </script>
 {% endblock %}


### PR DESCRIPTION
Since the inline scripts content changes based on sites in the
regions for the regional leaderboards HTML, the script was being
blocked by newly added CSP rules. Adding a nonce, instead of sha256
handles the issue of changing script content