### PR TITLE
Adds total site count in homepage and leaderboards

### DIFF
--- a/client/src/leaderboardtemplate.jade
+++ b/client/src/leaderboardtemplate.jade
@@ -8,6 +8,7 @@ mixin check(condition)
 
 .leaderboard
   if items.length > 0
+    p(class='sites-count')= `Total matched sites: ${items.length}`
     table#header-fixed
     table#header-normal
       thead

--- a/client/src/styles/_home.scss
+++ b/client/src/styles/_home.scss
@@ -17,7 +17,7 @@
 
 .stat-block {
   display: inline-block;
-  width: 32%;
+  width: 24%;
   vertical-align: top;
 }
 

--- a/home/models.py
+++ b/home/models.py
@@ -88,6 +88,7 @@ class HomePage(Page):
                                   if scan.onion_available]
 
         # Avoid divide by 0 if no Sites have been set up yet
+        context['total_sites'] = sites.count()
         if sites.count() > 0:
             context['percent_offering_https'] = math.floor(
                 len(sites_offering_https) / sites.count() * 100)

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -21,6 +21,10 @@
           <div class="stat-block-number">{{ percent_providing_onions }}%</div>
           <div class="stat-block-caption">Of news sites offer onion services</div>
         </div>
+        <div class="stat-block">
+          <div class="stat-block-number">{{ total_sites }}</div>
+          <div class="stat-block-caption">total news sites</div>
+        </div>
       </div>
 
       <div id="teaser">


### PR DESCRIPTION
I took the liberty in deciding where and how to show the count. Do let me know if anyone has any strong feelings about the language or placement of the count.

The count appears in homepage, the entire sites list and regional leaderboards. Also the count in sites and leaderboards is updated real time on searching.

Fixes #276 