### PR TITLE
Adds analytics url to connect-src CSP

### DIFF
--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -268,7 +268,10 @@ CSP_STYLE_SRC = (
     "'unsafe-inline'",
 )
 CSP_FRAME_SRC = ("'self'",)
-CSP_CONNECT_SRC = ("'self'",)
+CSP_CONNECT_SRC = (
+    "'self'",
+    "https://analytics.freedom.press",
+)
 
 # This will be used to evaluate Google Storage media support in staging
 GS_CUSTOM_ENDPOINT = os.environ.get(


### PR DESCRIPTION
The new matomo related javascript file makes requests to the analytics servers from within the JS code which is why we need to add https://analytics.freedom.press to connect-src CSP rule

Refs https://github.com/freedomofpress/fpf-www-projects/issues/169