### PR TITLE
Encode logs to UTF-8 by default

### DIFF
--- a/securethenews/settings/base.py
+++ b/securethenews/settings/base.py
@@ -347,6 +347,7 @@ DJANGO_LOGGING = {
     "DISABLE_EXISTING_LOGGERS": True,
     "PROPOGATE": False,
     "SQL_LOG": False,
+    "ENCODING": "utf-8",
 }
 
 LOGGING = {


### PR DESCRIPTION
ASCII encoding is not acceptable for logging the "content" response field, which may contain non-ascii characters.