### PR TITLE
Updates Wagtail to 2.11.8

### DIFF
--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -641,9 +641,9 @@ wagtail-autocomplete==0.6.2 \
     --hash=sha256:6dc63deffc3cc923893f3ff71bc0c0b06681bd8d95b69db833d33051191babab \
     --hash=sha256:c741301f8160ef3183c8961a604aecf033abbedff915d3f202ccaf61f50e08e5
     # via -r requirements.in
-wagtail==2.11.7 \
-    --hash=sha256:5159b569eacd4460d1584899353bd0f4088d8c6672cd389c02f20504bf98139a \
-    --hash=sha256:530b01fc20829b1c954ae14fa1d47f8e908f1300ea6f3edcbfe7619660da3144
+wagtail==2.11.8 \
+    --hash=sha256:460c4da96ecb84f817b80cfb5f9907a5be215df2f271c7569d6f58bd72e3c126 \
+    --hash=sha256:4b280742a7a97401b4c10dbcf7336dc99e367b5b95c21b9b3560abc697a9a627
     # via
     #   -r requirements.in
     #   wagtail-autocomplete

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -17,7 +17,7 @@ pyopenssl==19.0.0
 python-json-logger
 requests
 unittest-xml-reporting
-wagtail>=2.11.7,<2.12
+wagtail>=2.11.8,<2.12
 wagtail-autocomplete>=0.6.2
 wagtailmenus>=3.0
 whitenoise

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -551,9 +551,9 @@ wagtail-autocomplete==0.6.2 \
     --hash=sha256:6dc63deffc3cc923893f3ff71bc0c0b06681bd8d95b69db833d33051191babab \
     --hash=sha256:c741301f8160ef3183c8961a604aecf033abbedff915d3f202ccaf61f50e08e5
     # via -r requirements.in
-wagtail==2.11.7 \
-    --hash=sha256:5159b569eacd4460d1584899353bd0f4088d8c6672cd389c02f20504bf98139a \
-    --hash=sha256:530b01fc20829b1c954ae14fa1d47f8e908f1300ea6f3edcbfe7619660da3144
+wagtail==2.11.8 \
+    --hash=sha256:460c4da96ecb84f817b80cfb5f9907a5be215df2f271c7569d6f58bd72e3c126 \
+    --hash=sha256:4b280742a7a97401b4c10dbcf7336dc99e367b5b95c21b9b3560abc697a9a627
     # via
     #   -r requirements.in
     #   wagtail-autocomplete


### PR DESCRIPTION
> A cross-site scripting vulnerability exists in versions 2.13-2.13.1, versions 2.12-2.12.4, and versions prior to 2.11.8. When the {% include_block %} template tag is used to output the value of a plain-text StreamField block (CharBlock, TextBlock or a similar user-defined block derived from FieldBlock), and that block does not specify a template for rendering, the tag output is not properly escaped as HTML. This could allow users to insert arbitrary HTML or scripting. This vulnerability is only exploitable by users with the ability to author StreamField content (i.e. users with 'editor' access to the Wagtail admin). Patched versions have been released as Wagtail 2.11.8 (for the LTS 2.11 branch), Wagtail 2.12.5, and Wagtail 2.13.2 (for the current 2.13 branch). As a workaround, site implementors who are unable to upgrade to a current supported version should audit their use of {% include_block %} to ensure it is not used to output CharBlock / TextBlock values with no associated template. Note that this only applies where {% include_block %} is used directly on that block (uses of include_block on a block containing a CharBlock / TextBlock, such as a StructBlock, are unaffected). In these cases, the tag can be replaced with Django's {{ ... }} syntax - e.g. {% include_block my_title_block %} becomes {{ my_title_block }}. See CVE-2021-32681.