### PR TITLE
Halt npm-audit CI job if package-lock.json is not changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,15 @@ reuse-blerbs:
         pip install pipenv
         pipenv install
 
-version: 2
+version: 2.1
+commands:
+  check-changed-files-or-halt:
+    parameters:
+      pattern:
+        type: string
+    steps:
+      - run: git diff --name-only develop...HEAD|grep -q '<< parameters.pattern >>' || circleci step halt
+
 jobs:
   safety_check:
     machine:
@@ -45,6 +53,8 @@ jobs:
     working_directory: ~/freedom.press
     steps:
       - checkout
+      - check-changed-files-or-halt:
+          pattern: ^package-lock.json$
 
       - *python_prereqs
 


### PR DESCRIPTION
Refs https://github.com/freedomofpress/fpf-www-projects/issues/190

This pull request adds a [command](https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21) to halt the npm audit CI job (but proceed with the overall workflow) when package-log.json has not been changed on the branch being checked.

The result is that, for our branch checks, job will get the green checkmark unless (a) package-json.json has been updated on that branch, _and_ (b) there is a vulnerability detected by npm audit. 

To see how this works, check out these two job results:

1. [In which no npm packages were updated](https://app.circleci.com/pipelines/github/freedomofpress/securethenews/1074/workflows/2ce6602e-a3b9-4980-bf83-183b44311a34/jobs/3680)
![image](https://user-images.githubusercontent.com/561931/123706690-9552d780-d836-11eb-8818-42a86627956f.png)

2. [In which underscore.js was changed to an insecure version](https://app.circleci.com/pipelines/github/freedomofpress/securethenews/1075/workflows/6fdbf6a4-75f9-4ca8-8220-0bbf3cd737b7/jobs/3683)

![image](https://user-images.githubusercontent.com/561931/123706630-82d89e00-d836-11eb-85a0-3a922719bff8.png)

In job 1, our command halts the rest of the job and returns green.

Note that this does not prevent all potential "unrelated" failures on CI because of npm audit. There is still the case that package-lock.json might be updated to install `package-a` while `package-b` causes an audit failure.

However, I do think this is a fairly simple way (it's a one-liner in git and grep) to prevent almost all of the hard failures we see related to npm audit, while still retaining protection for when packages are introduced or upgraded.