### PR TITLE
Updates lodash orderBy to use values instead of the key string

### DIFF
--- a/client/src/leaderboard.js
+++ b/client/src/leaderboard.js
@@ -65,9 +65,11 @@ export default Backbone.View.extend({
         || site.domain.toLowerCase().indexOf(this.state.get('searchString')) !== -1;
     });
 
-    let orderByIdentity = this.state.get('orderBy')
-    if (orderByIdentity == 'https_available') {
+    let orderByIdentity = ''
+    if (this.state.get('orderBy') == 'https_available') {
       orderByIdentity = (item) => item.valid_https && !item.downgrades_https
+    } else {
+      orderByIdentity = (item) => item[this.state.get('orderBy')] || '';
     }
     models = orderBy(models, [orderByIdentity, sortableName], [this.state.get('order'), 'asc']);
 


### PR DESCRIPTION
Fixes #332 

As mentioned in the code comments, `onion_available along` with most other boolean fields allow for null because it may not be possible to determine their values (for example, if the site is down at the time of the scan).

I have hence changed the way we do orderBy (since most of the orderBy fields involve a Nullable Boolean field). Lodash can handle both the values and the key to sort by. So in this PR I have updated such that it uses the value, and anytime the value is `null`, it uses blank string `''` instead.