### PR TITLE
Disable Google Storage default file overwrite behavior

### DIFF
--- a/securethenews/settings/production.py
+++ b/securethenews/settings/production.py
@@ -123,6 +123,7 @@ elif os.environ.get('GS_BUCKET_NAME'):
     GS_BUCKET_NAME = os.environ['GS_BUCKET_NAME']
     GS_MEDIA_PATH = os.environ.get('GS_MEDIA_PATH', 'media')
     GS_STATIC_PATH = os.environ.get('GS_STATIC_PATH', 'static')
+    GS_FILE_OVERWRITE = os.environ.get('GS_FILE_OVERWRITE') == 'True'
 
     DEFAULT_FILE_STORAGE = 'securethenews.gce_storage.MediaStorage'
     if 'GS_STORE_STATIC' in os.environ:


### PR DESCRIPTION
See documentation here for more info on the GS_FILE_OVERWRITE option:

https://django-storages.readthedocs.io/en/latest/backends/gcloud.html

This pull request will disable the default `django-storages` behavior for overwriting files unless the environment variable
`GS_FILE_OVERWRITE` is set to the string `"True"`.