### PR TITLE
Split version file into full (/admin) and short (/health)

### DIFF
--- a/home/tests/test_views.py
+++ b/home/tests/test_views.py
@@ -6,7 +6,11 @@ from home.models import HomePage
 
 class HealthCheckTestCase(TestCase):
     def test_health_check_url_returns_200_status(self):
-        self.response = self.client.get('/health/ok/')
+        self.response = self.client.get("/health/ok/")
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_version_info_url_returns_200_status(self):
+        self.response = self.client.get("/health/version/")
         self.assertEqual(self.response.status_code, 200)
 
 
@@ -15,13 +19,13 @@ class HomePageTestCase(TestCase):
         site = Site.objects.get()
         page = Page.get_first_root_node()
         home = HomePage(
-            title='Test Title',
-            main_title='Test 1',
-            sub_title='Test 2',
-            why_header='Test 3',
-            how_header='Test 4',
-            why_body='Test 5',
-            how_body='Test 6',
+            title="Test Title",
+            main_title="Test 1",
+            sub_title="Test 2",
+            why_header="Test 3",
+            how_header="Test 4",
+            why_body="Test 5",
+            how_body="Test 6",
         )
         self.home_page = page.add_child(instance=home)
 
@@ -31,8 +35,8 @@ class HomePageTestCase(TestCase):
     @override_settings(ANALYTICS_ENABLED=False)
     def test_analytics_settings_are_in_page_context(self):
         response = self.client.get(self.home_page.url)
-        self.assertIn('django_settings', response.context)
+        self.assertIn("django_settings", response.context)
         self.assertEqual(
-            response.context['django_settings']['ANALYTICS_ENABLED'],
+            response.context["django_settings"]["ANALYTICS_ENABLED"],
             False,
         )

--- a/home/views.py
+++ b/home/views.py
@@ -4,19 +4,34 @@ from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
 
 
-DEPLOYINFO_PATH = os.environ.get('DJANGO_VERSION_FILE', '/deploy/version')
+VERSION_INFO_SHORT_PATH = os.environ.get(
+    "DJANGO_SHORT_VERSION_FILE", "/deploy/version-short.txt"
+)
+VERSION_INFO_FULL_PATH = os.environ.get(
+    "DJANGO_FULL_VERSION_FILE", "/deploy/version-full.txt"
+)
+
+
+def read_version_info_file(p):
+    try:
+        with open(p, "r") as f:
+            return f.read()
+    except FileNotFoundError:
+        return f"<file not found at {p}>"
 
 
 def deploy_info_view(request):
-    try:
-        with open(DEPLOYINFO_PATH, 'r') as f:
-            contents = f.read()
-    except FileNotFoundError:
-        contents = "<file not found at {}>".format(DEPLOYINFO_PATH)
-    return HttpResponse(contents, content_type='text/plain')
+    version_full_text = read_version_info_file(VERSION_INFO_FULL_PATH)
+    return HttpResponse(version_full_text, content_type="text/plain")
 
 
 @never_cache
 def health_ok(request):
     """Lightweight health-check with a 200 response code."""
     return HttpResponse("okay")
+
+
+def health_version(request):
+    """Also a health check, but returns the commit short-hash."""
+    version_short_text = read_version_info_file(VERSION_INFO_SHORT_PATH)
+    return HttpResponse(version_short_text)

--- a/securethenews/urls.py
+++ b/securethenews/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path('documents/', include(wagtaildocs_urls)),
 
     path('health/ok/', home.views.health_ok),
+    path('health/version/', home.views.health_version),
 
     path('search/', search_views.search, name='search'),
 


### PR DESCRIPTION
First site listed on https://github.com/freedomofpress/fpf-www-projects/issues/220

This overhauls the version script a bit to have better output (try it on `prod` vs `develop` vs a detached HEAD), adds a test, and the content-type for `/health/ok`.

It probably doesn't matter for efficiency but (not a change from before) this still builds the text files at boot time and reads them on every request. We could, for efficiency, build once at container build time and read once at app startup.

If this looks good, I can go ahead and implement for other sites.