### PR TITLE
Remove safety-check related tools from pipenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,30 +22,31 @@ commands:
 
 jobs:
   safety_check:
-    machine:
-      image: ubuntu-2004:202101-01
+    docker:
+      - image: cimg/python:3.9
     working_directory: ~/securethenews
     steps:
       - checkout
 
-      - *python_prereqs
+      - run:
+          name: Install pip dependencies
+          command: pip install --require-hashes -r securethenews/dev-requirements.txt
 
       - run:
           name: Check Python dependencies for CVEs
           command: |
-            pipenv install --selective-upgrade safety
-            pipenv run make safety
+            pip install --upgrade safety
+            ./scripts/safety_check.py
 
       - run:
           name: linters on the source
-          command: |
-            pipenv run make lint
+          command: flake8
 
       - run:
           name: Static code analysis for vulnerabilities
           command: |
-            pipenv install --selective-upgrade bandit
-            pipenv run make bandit
+            pip install --upgrade bandit
+            make bandit
 
   npm_audit:
     machine:

--- a/securethenews/dev-requirements.in
+++ b/securethenews/dev-requirements.in
@@ -2,3 +2,4 @@
 colorama<1
 coverage
 ipdb
+flake8

--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -223,6 +223,10 @@ elasticsearch==7.8.0 \
 et-xmlfile==1.0.1 \
     --hash=sha256:614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b
     # via openpyxl
+flake8==4.0.1 \
+    --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
+    --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
+    # via -r dev-requirements.in
 google-api-core==1.21.0 \
     --hash=sha256:7b65e8e5ee59bd7517eab2bf9b3008e7b50fd9fb591d4efd780ead6859cd904b \
     --hash=sha256:fea9a434068406ddabe2704988d24d6c5bde3ecfc40823a34f43892d017b14f6
@@ -339,6 +343,10 @@ mbstrdecoder==1.0.0 \
     #   pytablereader
     #   pytablewriter
     #   typepy
+mccabe==0.6.1 \
+    --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
+    --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
+    # via flake8
 msgfy==0.1.0 \
     --hash=sha256:474c08302cd56ccee1300ac7976a01ebd1e42716fc9bcd947d39a311a15b7012 \
     --hash=sha256:ce8a8c8c223279fa0a2c0f278eec139fcf761ca4eb98f179f54a1b96f53514f5
@@ -479,7 +487,7 @@ protobuf==3.12.2 \
     # via
     #   google-api-core
     #   googleapis-common-protos
-https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304 \
+pshtt @ https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304 \
     --hash=sha256:56e10b98409223c2800c25268822468579a7dad0faebc8ed31f9d12ef7b80381
     # via -r requirements.in
 psycopg2==2.8.5 \
@@ -514,10 +522,18 @@ pyasn1-modules==0.2.8 \
     --hash=sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e \
     --hash=sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74
     # via google-auth
+pycodestyle==2.8.0 \
+    --hash=sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20 \
+    --hash=sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f
+    # via flake8
 pycparser==2.20 \
     --hash=sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0 \
     --hash=sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705
     # via cffi
+pyflakes==2.4.0 \
+    --hash=sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c \
+    --hash=sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e
+    # via flake8
 pygments==2.9.0 \
     --hash=sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f \
     --hash=sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -398,7 +398,7 @@ protobuf==3.12.2 \
     # via
     #   google-api-core
     #   googleapis-common-protos
-https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304 \
+pshtt @ https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304 \
     --hash=sha256:56e10b98409223c2800c25268822468579a7dad0faebc8ed31f9d12ef7b80381
     # via -r requirements.in
 psycopg2==2.8.5 \


### PR DESCRIPTION
This change removes `flake8`, `safety` and `bandit` from Pipenv and
adjusts the makefile (and related scripts) to run them either inside a
docker container or directly in the CI environment.

The reason for doing this is a recent update to Pipenv seemed to be
breaking the make commands.  Not fully sure what was going on with it
but it seems like we want to move away from Pipenv anyway and it's not
too hard to remove these packages from it.