### PR TITLE
Use print(flush=True) to log scan progress

### DIFF
--- a/sites/management/commands/scan.py
+++ b/sites/management/commands/scan.py
@@ -140,5 +140,5 @@ class Command(BaseCommand):
 
         with transaction.atomic():
             for site in sites:
-                self.stdout.write('Scanning: {}'.format(site.domain))
+                print(f"Scanning: {site.domain}", file=self.stdout, flush=True)
                 scan(site)


### PR DESCRIPTION
When looking at logs of a scan container with `kubectl logs` or in ELK, nothing is actually printed until the entire scan is done. I believe this is because block buffering is being used and not enough data is printed for force a write. Instead, let's force a flush after each line. We don't have to call `.write()` for this; we can just use `print()`.