### PR TITLE
Updates django to version 2.2.25

### DIFF
--- a/securethenews/dev-requirements.txt
+++ b/securethenews/dev-requirements.txt
@@ -142,9 +142,9 @@ decorator==4.4.2 \
     # via
     #   ipython
     #   traitlets
-django==2.2.24 \
-    --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7 \
-    --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92
+django==2.2.25 \
+    --hash=sha256:08bad7ef7e90286b438dbe1412c3e633fbc7b96db04735f0c7baadeed52f3fad \
+    --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
     # via
     #   -r requirements.in
     #   django-anymail

--- a/securethenews/requirements.in
+++ b/securethenews/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304
-Django>=2.2.24,<2.3
+Django>=2.2.25,<2.3
 django-cors-headers>=3.0.0
 django-crispy-forms>=1.7.2
 django-csp

--- a/securethenews/requirements.txt
+++ b/securethenews/requirements.txt
@@ -92,9 +92,9 @@ dataproperty==0.52.0 \
     #   pytablereader
     #   pytablewriter
     #   tabledata
-django==2.2.24 \
-    --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7 \
-    --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92
+django==2.2.25 \
+    --hash=sha256:08bad7ef7e90286b438dbe1412c3e633fbc7b96db04735f0c7baadeed52f3fad \
+    --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
     # via
     #   -r requirements.in
     #   django-anymail


### PR DESCRIPTION
Fixes CVE-2021-44420: Potential bypass of an upstream access control
based on URL paths

See https://docs.djangoproject.com/en/4.0/releases/2.2.25/ for more
information.